### PR TITLE
Eagerly fill marks and matches cache

### DIFF
--- a/src/logdata/include/data/linetypes.h
+++ b/src/logdata/include/data/linetypes.h
@@ -158,5 +158,6 @@ template<typename Iterator>
 LineNumber lookupLineNumber( Iterator begin, Iterator end, LineNumber lineNum )
 {
     const auto lowerBound = std::lower_bound( begin, end, lineNum );
-    return LineNumber( static_cast<LineNumber::UnderlyingType>( std::distance( begin, lowerBound ) ) );
+    const auto it = lowerBound != end || begin == end ? lowerBound : std::prev( end );
+    return LineNumber( static_cast<LineNumber::UnderlyingType>( std::distance( begin, it ) ) );
 }

--- a/src/logdata/include/data/linetypes.h
+++ b/src/logdata/include/data/linetypes.h
@@ -149,8 +149,7 @@ template <typename T> bool lookupLineNumber(
     using std::begin;
     using std::distance;
     using std::end;
-    auto notLess = std::lower_bound( begin( list ), end( list ), lineNumber,
-        [](typename T::const_reference lhs, typename T::const_reference rhs) { return lhs.lineNumber() < rhs.lineNumber(); });
+    auto notLess = std::lower_bound( begin( list ), end( list ), lineNumber );
     foundIndex = static_cast<uint32_t>( distance( begin( list ), notLess ) );
     return notLess != end( list ) && notLess->lineNumber() == lineNumber;
 }

--- a/src/logdata/include/data/logfiltereddata.h
+++ b/src/logdata/include/data/logfiltereddata.h
@@ -189,7 +189,6 @@ class LogFilteredData : public AbstractLogData {
     // when visibility_ == MarksAndMatches
     // (QVector store actual objects instead of pointers)
     mutable std::vector<FilteredItem> filteredItemsCache_;
-    mutable bool filteredItemsCacheDirty_;
 
     LogFilteredDataWorkerThread workerThread_;
     Marks marks_;
@@ -219,6 +218,12 @@ class LogFilteredData : public AbstractLogData {
     LineNumber findFilteredLine( LineNumber lineNum ) const;
 
     void regenerateFilteredItemsCache() const;
+    void insertIntoFilteredItemsCache( FilteredItem&& item );
+    void removeFromFilteredItemsCache( FilteredItem&& item );
+    void removeAllFromFilteredItemsCache( FilteredLineType type );
+
+    // update maxLengthMarks_ when a Mark was removed.
+    void updateMaxLengthMarks( LineNumber removed_line );
 };
 
 // A class representing a Mark or Match.

--- a/src/logdata/include/data/logfiltereddata.h
+++ b/src/logdata/include/data/logfiltereddata.h
@@ -178,7 +178,6 @@ class LogFilteredData : public AbstractLogData {
 
     const LogData* sourceLogData_;
     QRegularExpression currentRegExp_;
-    bool searchDone_;
     LineLength maxLength_;
     LineLength maxLengthMarks_;
     // Number of lines of the LogData that has been searched for:

--- a/src/logdata/include/data/logfiltereddata.h
+++ b/src/logdata/include/data/logfiltereddata.h
@@ -222,8 +222,8 @@ class LogFilteredData : public AbstractLogData {
     // It refers to the index of the singular arrays (Marks or SearchResultArray) where the item was inserted.
     void insertIntoFilteredItemsCache( size_t start_index, FilteredItem&& item );
     void insertIntoFilteredItemsCache( FilteredItem&& item );
-    // Insert entries from matching_lines_ into filteredItemsCache_ starting by start_index.
-    void insertMatchesIntoFilteredItemsCache( size_t start_index );
+    // Insert new matches into matching_lines_ and filteredItemsCache_
+    void insertNewMatches( const SearchResultArray& new_matches );
     // remove_index can be passed in as an optimization when finding the item.
     // It refers to the index of the singular arrays (Marks or SearchResultArray) where the item was removed.
     void removeFromFilteredItemsCache( size_t remove_index, FilteredItem&& item );

--- a/src/logdata/include/data/logfiltereddata.h
+++ b/src/logdata/include/data/logfiltereddata.h
@@ -218,7 +218,15 @@ class LogFilteredData : public AbstractLogData {
     LineNumber findFilteredLine( LineNumber lineNum ) const;
 
     void regenerateFilteredItemsCache() const;
+    // start_index can be passed in as an optimization when finding the item.
+    // It refers to the index of the singular arrays (Marks or SearchResultArray) where the item was inserted.
+    void insertIntoFilteredItemsCache( size_t start_index, FilteredItem&& item );
     void insertIntoFilteredItemsCache( FilteredItem&& item );
+    // Insert entries from matching_lines_ into filteredItemsCache_ starting by start_index.
+    void insertMatchesIntoFilteredItemsCache( size_t start_index );
+    // remove_index can be passed in as an optimization when finding the item.
+    // It refers to the index of the singular arrays (Marks or SearchResultArray) where the item was removed.
+    void removeFromFilteredItemsCache( size_t remove_index, FilteredItem&& item );
     void removeFromFilteredItemsCache( FilteredItem&& item );
     void removeAllFromFilteredItemsCache( FilteredLineType type );
 

--- a/src/logdata/include/data/logfiltereddataworkerthread.h
+++ b/src/logdata/include/data/logfiltereddataworkerthread.h
@@ -81,8 +81,10 @@ class SearchData
 
     // Atomically get all the search data
     // appending more results to passed array
-    void getAll( LineLength* length, SearchResultArray* matches,
-            LinesCount* nbLinesProcessed ) const;
+    void getAll( LineLength* length, SearchResultArray* matches, LinesCount* nbLinesProcessed ) const;
+    // Atomically get all the search data
+    // appending the missing entries. Does not check that the existing entries match.
+    void getAllMissing( LineLength* length, SearchResultArray* matches, LinesCount* nbLinesProcessed ) const;
     // Atomically set all the search data
     // (overwriting the existing)
     // (the matches are always moved)
@@ -183,9 +185,8 @@ class LogFilteredDataWorkerThread : public QThread
     // Interrupts the search if one is in progress
     void interrupt();
 
-    // Returns a copy of the current indexing data
-    void getSearchResult( LineLength* maxLength, SearchResultArray* searchMatches,
-           LinesCount* nbLinesProcessed );
+    // Updates the array by copying the current indexing data
+    void updateSearchResult( LineLength* maxLength, SearchResultArray* searchMatches, LinesCount* nbLinesProcessed );
 
   signals:
     // Sent during the indexing process to signal progress

--- a/src/logdata/include/data/marks.h
+++ b/src/logdata/include/data/marks.h
@@ -112,6 +112,9 @@ class Marks {
         const Mark* operator->() const
         { return &(*internal_iter_); }
 
+        bool operator==( const const_iterator& other ) const
+        { return ( internal_iter_ != other.internal_iter_ ); }
+
         bool operator!=( const const_iterator& other ) const
         { return ( internal_iter_ != other.internal_iter_ ); }
 

--- a/src/logdata/include/data/marks.h
+++ b/src/logdata/include/data/marks.h
@@ -70,7 +70,9 @@ class Marks {
     // Add a mark at the given line, optionally identified by the given char
     // If a mark for this char already exist, the previous one is replaced.
     // It will happily add marks anywhere, even at stupid indexes.
-    void addMark( LineNumber line, QChar mark = QChar() );
+    // Returns the index at which the mark was inserted,
+    // such that getLineMarkedByIndex( addMark( line ) ) == line.
+    uint32_t addMark( LineNumber line, QChar mark = QChar() );
     // Get the (unique) mark identified by the passed char.
     LineNumber getMark( QChar mark ) const;
     // Returns wheither the passed line has a mark on it.
@@ -79,7 +81,8 @@ class Marks {
     void deleteMark( QChar mark );
     // Delete the mark present on the passed line or do nothing if there is
     // none.
-    void deleteMark( LineNumber line );
+    // Returns the index at which the mark was deleted.
+    uint32_t deleteMark( LineNumber line );
     // Get the line marked identified by the index (in this list) passed.
     LineNumber getLineMarkedByIndex( int index ) const
     { return marks_[index].lineNumber(); }

--- a/src/logdata/src/marks.cpp
+++ b/src/logdata/src/marks.cpp
@@ -50,7 +50,7 @@ Marks::Marks() : marks_()
 {
 }
 
-void Marks::addMark( LineNumber line, QChar mark )
+uint32_t Marks::addMark( LineNumber line, QChar mark )
 {
     // Look for the index immediately before
     uint32_t index;
@@ -68,6 +68,8 @@ void Marks::addMark( LineNumber line, QChar mark )
 
     // 'mark' is not used yet
     mark = mark;
+
+    return index;
 }
 
 LineNumber Marks::getMark( QChar mark ) const
@@ -90,7 +92,7 @@ void Marks::deleteMark( QChar mark )
     mark = mark;
 }
 
-void Marks::deleteMark( LineNumber line )
+uint32_t Marks::deleteMark( LineNumber line )
 {
     uint32_t index;
 
@@ -98,6 +100,8 @@ void Marks::deleteMark( LineNumber line )
     {
         marks_.erase( marks_.begin() + index );
     }
+
+    return index;
 }
 
 void Marks::clear()

--- a/tests/logfiltereddataTest.cpp
+++ b/tests/logfiltereddataTest.cpp
@@ -169,7 +169,7 @@ SCENARIO( "filtered log data", "[logdata]") {
             config.setUseParallelSearch( threadPoolSize > 0 );
 
             auto filtered_lines = filtered_data->getNbLine();
-            REQUIRE( filtered_lines.get() == 0);
+            REQUIRE( filtered_lines.get() == 0 );
 
             SafeQSignalSpy searchProgressSpy {
                         filtered_data.get(),
@@ -180,21 +180,21 @@ SCENARIO( "filtered log data", "[logdata]") {
 
             THEN( "Matched lines are in data" ) {
                 QList<QVariant> progressArgs = searchProgressSpy.last();
-                REQUIRE( qvariant_cast<LinesCount>( progressArgs.at(0) ) == 50_lcount );
+                REQUIRE( qvariant_cast<LinesCount>( progressArgs.at( 0 ) ) == 50_lcount );
 
                 const auto matches_count = filtered_data->getNbMatches();
                 REQUIRE( matches_count == 50_lcount );
 
-                const auto lines = filtered_data->getExpandedLines(0_lnum,
-                                                                   matches_count );
-                for ( const auto& l: lines) {
+                const auto lines = filtered_data->getExpandedLines( 0_lnum,
+                                                                    matches_count );
+                for ( const auto& l: lines ) {
                     REQUIRE( l.endsWith( '9' ) );
                 }
             }
 
             WHEN( "Add marks at matched line" ) {
-                const auto& firstMatchedLine = filtered_data->getLineString(0_lnum);
-                REQUIRE( firstMatchedLine.right(2).toStdString() == "09");
+                const auto& firstMatchedLine = filtered_data->getLineString( 0_lnum );
+                REQUIRE( firstMatchedLine.right(2).toStdString() == "09" );
 
                 filtered_data->addMark( 9_lnum );
 
@@ -211,7 +211,7 @@ SCENARIO( "filtered log data", "[logdata]") {
                 }
             }
 
-            WHEN( "Has mixed marks and mathes" ) {
+            WHEN( "Has mixed marks and matches" ) {
                 filtered_data->addMark( 9_lnum );
                 filtered_data->addMark( 5_lnum );
 
@@ -224,7 +224,7 @@ SCENARIO( "filtered log data", "[logdata]") {
                     }
                 }
 
-                WHEN( "Only mathes are visible" ) {
+                WHEN( "Only matches are visible" ) {
                     filtered_data->setVisibility( Visibility::MatchesOnly );
 
                     THEN( "Has only matches lines count" ) {
@@ -268,7 +268,7 @@ SCENARIO( "filtered log data", "[logdata]") {
                 WHEN( "For matched line" ) {
                     auto original_line = filtered_data->getMatchingLineNumber( 1_lnum );
 
-                    const auto& firstMatchedLine = filtered_data->getLineString(1_lnum);
+                    const auto& firstMatchedLine = filtered_data->getLineString( 1_lnum );
                     REQUIRE( firstMatchedLine.right(2).toStdString() == "09");
 
                     THEN( "Original line is on match" ) {


### PR DESCRIPTION
As promised in #37, here's the rebased work.

For some reason I also need to apply the following patch, otherwise my `item` is corrupted. I think this occurs sometimes when adding marks. While this does fix it, I don't see why the previous code would be wrong. Maybe it's just something else on my setup triggering the failure, so I didn't include it.
Make sure to play with the cache a little! Well, I'm sure you will anyways, to evaluate if you want this change or not.
```
diff --git a/src/logdata/include/data/logfiltereddata.h b/src/logdata/include/data/logfiltereddata.h
index b66489b..d529f74 100644
--- a/src/logdata/include/data/logfiltereddata.h
+++ b/src/logdata/include/data/logfiltereddata.h
@@ -220,8 +220,8 @@ class LogFilteredData : public AbstractLogData {
     void regenerateFilteredItemsCache() const;
     // start_index can be passed in as an optimization when finding the item.
     // It refers to the index of the singular arrays (Marks or SearchResultArray) where the item was inserted.
-    void insertIntoFilteredItemsCache( size_t start_index, FilteredItem&& item );
-    void insertIntoFilteredItemsCache( FilteredItem&& item );
+    void insertIntoFilteredItemsCache( size_t start_index, const FilteredItem& item );
+    void insertIntoFilteredItemsCache( const FilteredItem& item );
     // Insert new matches into matching_lines_ and filteredItemsCache_
     void insertNewMatches( const SearchResultArray& new_matches );
     // remove_index can be passed in as an optimization when finding the item.
diff --git a/src/logdata/src/logfiltereddata.cpp b/src/logdata/src/logfiltereddata.cpp
index 5978fe5..03df611 100644
--- a/src/logdata/src/logfiltereddata.cpp
+++ b/src/logdata/src/logfiltereddata.cpp
@@ -593,7 +593,7 @@ void LogFilteredData::regenerateFilteredItemsCache() const
     LOG(logDEBUG) << "finished regenerateFilteredItemsCache, size " << filteredItemsCache_.size();
 }
 
-void LogFilteredData::insertIntoFilteredItemsCache( size_t insert_index, FilteredItem&& item )
+void LogFilteredData::insertIntoFilteredItemsCache( size_t insert_index, const FilteredItem& item )
 {
     using std::begin;
     using std::end;
@@ -616,7 +616,7 @@ void LogFilteredData::insertIntoFilteredItemsCache( size_t insert_index, Filtere
     }
 }
 
-void LogFilteredData::insertIntoFilteredItemsCache( FilteredItem&& item )
+void LogFilteredData::insertIntoFilteredItemsCache( const FilteredItem& item )
 {
     insertIntoFilteredItemsCache( 0, std::move( item ) );
 }
```