### PR TITLE
Improve Hidpi displays support

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -227,7 +227,9 @@ int main( int argc, char* argv[] )
 
     // No icon in menus
     QCoreApplication::setAttribute( Qt::AA_DontShowIconsInMenus );
+#ifdef Q_OS_WIN
     QCoreApplication::setAttribute( Qt::AA_DisableWindowContextHelpButton );
+#endif
 
     // FIXME: should be replaced by a two staged init of MainWindow
     Configuration::getSynced();

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -87,6 +87,10 @@ static void print_version();
 
 int main( int argc, char* argv[] )
 {
+    // This attribute must be set before QGuiApplication is constructed:
+    QCoreApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
+    // We support high-dpi (aka Retina) displays
+    QCoreApplication::setAttribute( Qt::AA_UseHighDpiPixmaps );
     SingleApplication app( argc, argv, true, SingleApplication::SecondaryNotification );
 
     // Register types for Qt
@@ -221,11 +225,9 @@ int main( int argc, char* argv[] )
                           &MessageReceiver::receiveMessage, Qt::QueuedConnection );
     }
 
-    // We support high-dpi (aka Retina) displays
-    app.setAttribute( Qt::AA_UseHighDpiPixmaps );
-
     // No icon in menus
-    app.setAttribute( Qt::AA_DontShowIconsInMenus );
+    QCoreApplication::setAttribute( Qt::AA_DontShowIconsInMenus );
+    QCoreApplication::setAttribute( Qt::AA_DisableWindowContextHelpButton );
 
     // FIXME: should be replaced by a two staged init of MainWindow
     Configuration::getSynced();


### PR DESCRIPTION
Below are screenshots of resulting changes.
Original `Highlighters` dialog on my 4K display looked like this:
![image](https://user-images.githubusercontent.com/2953741/64923899-449bf700-d7e7-11e9-9d85-0fe11983fea7.png)


After proposed commit it looks like this:
![image](https://user-images.githubusercontent.com/2953741/64923880-10c0d180-d7e7-11e9-8ec7-b20acc33eb6d.png)


Also notice left bar with Marks and line numbers; TabBar vertical size etc:
![image](https://user-images.githubusercontent.com/2953741/64923702-4d8bc900-d7e5-11e9-81e2-e0367fdeb9ed.png)
