### PR TITLE
Fix #89

### DIFF
--- a/src/logdata/include/data/abstractlogdata.h
+++ b/src/logdata/include/data/abstractlogdata.h
@@ -101,6 +101,15 @@ class AbstractLogData : public QObject {
         return LineLength( line.length() + total_spaces );
     }
 
+    // The "type" of a line, which will appear in the FilteredView
+    enum class LineTypeFlags
+    {
+        Plain = 0,      // 0 can be checked like a proper flag in QFlags
+        Match = 1 << 0,
+        Mark  = 1 << 1,
+    };
+    Q_DECLARE_FLAGS( LineType, LineTypeFlags )
+
   protected:
     // Internal function called to get a given line
     virtual QString doGetLineString( LineNumber line ) const = 0;
@@ -147,5 +156,7 @@ class AbstractLogData : public QObject {
         return untabified_line;
     }
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( AbstractLogData::LineType )
 
 #endif

--- a/src/logdata/include/data/logfiltereddata.h
+++ b/src/logdata/include/data/logfiltereddata.h
@@ -90,9 +90,6 @@ class LogFilteredData : public AbstractLogData {
     // given original line number
     LineNumber getLineIndexNumber( LineNumber lineNumber ) const;
 
-    // Returns whether the line number passed is in our list of matching ones.
-    bool isLineInMatchingList( LineNumber lineNumber );
-
     // Returns the number of lines in the source log data
     LinesCount getNbTotalLines() const;
     // Returns the number of matches (independently of the visibility)
@@ -100,18 +97,8 @@ class LogFilteredData : public AbstractLogData {
     // Returns the number of marks (independently of the visibility)
     LinesCount getNbMarks() const;
 
-    // Returns the reason why the line at the passed index is in the filtered
-    // data.  It can be because it is either a mark or a match.
-    enum class FilteredLineTypeFlags
-    {
-        None  = 0,        // this is for internal use
-        Match = 1 << 0,
-        Mark  = 1 << 1,
-    };
-
-    Q_DECLARE_FLAGS(FilteredLineType, FilteredLineTypeFlags)
-
-    FilteredLineType filteredLineTypeByIndex(LineNumber index ) const;
+    LineType lineTypeByIndex( LineNumber index ) const;
+    LineType lineTypeByLine( LineNumber index ) const;
 
     // Marks interface (delegated to a Marks object)
 
@@ -120,8 +107,6 @@ class LogFilteredData : public AbstractLogData {
     void addMark( LineNumber line, QChar mark = QChar() );
     // Get the (unique) mark identified by the passed char.
     LineNumber getMark( QChar mark ) const;
-    // Returns wheither the passed line has a mark on it.
-    bool isLineMarked( LineNumber line ) const;
     // Get the first mark after the line passed
     OptionalLineNumber getMarkAfter( LineNumber line ) const;
     // Get the first mark before the line passed
@@ -138,13 +123,14 @@ class LogFilteredData : public AbstractLogData {
 
     // Changes what the AbstractLogData returns via its getXLines/getNbLines
     // API.
-    enum class Visibility
+    enum class VisibilityFlags
     {
-        MatchesOnly,
-        MarksOnly,
-        MarksAndMatches
+        None    = static_cast<LineType::Int>( LineTypeFlags::Plain ), //this is for internal use
+        Matches = static_cast<LineType::Int>( LineTypeFlags::Match ),
+        Marks   = static_cast<LineType::Int>( LineTypeFlags::Mark  ),
     };
-    Q_ENUM( Visibility );
+    Q_ENUM( VisibilityFlags );
+    Q_DECLARE_FLAGS( Visibility, VisibilityFlags )
     void setVisibility( Visibility visibility );
 
   signals:
@@ -172,6 +158,11 @@ class LogFilteredData : public AbstractLogData {
 
     void doAttachReader() const override;
     void doDetachReader() const override;
+
+    // Returns whether the line number passed is in our list of matching ones.
+    bool isLineMatched( LineNumber lineNumber ) const;
+    // Returns wheither the passed line has a mark on it.
+    bool isLineMarked( LineNumber line ) const;
 
     // List of the matching line numbers
     SearchResultArray matching_lines_;
@@ -229,7 +220,7 @@ class LogFilteredData : public AbstractLogData {
     // It refers to the index of the singular arrays (Marks or SearchResultArray) where the item was removed.
     void removeFromFilteredItemsCache( size_t remove_index, FilteredItem&& item );
     void removeFromFilteredItemsCache( FilteredItem&& item );
-    void removeAllFromFilteredItemsCache( FilteredLineType type );
+    void removeAllFromFilteredItemsCache( LineType type );
 
     // update maxLengthMarks_ when a Mark was removed.
     void updateMaxLengthMarks( LineNumber removed_line );
@@ -245,7 +236,7 @@ class LogFilteredData::FilteredItem {
   public:
     // A default ctor seems to be necessary for QVector
     FilteredItem();
-    FilteredItem( LineNumber lineNumber, FilteredLineType type )
+    FilteredItem( LineNumber lineNumber, LineType type )
         : lineNumber_{ lineNumber }
         , type_ { type }
     {}
@@ -253,14 +244,14 @@ class LogFilteredData::FilteredItem {
     LineNumber lineNumber() const
     { return lineNumber_; }
 
-    FilteredLineType type() const
+    LineType type() const
     { return type_; }
 
-    void add( FilteredLineType type )
+    void add( LineType type )
     { type_ |= type; }
 
     // Returns whether any type-flag is left.
-    bool remove( FilteredLineType type )
+    bool remove( LineType type )
     {
         type_ &= ~type;
         return !!type_;
@@ -274,10 +265,10 @@ class LogFilteredData::FilteredItem {
 
   private:
     LineNumber lineNumber_;
-    FilteredLineType type_;
+    LineType type_;
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(LogFilteredData::FilteredLineType)
-
+Q_DECLARE_OPERATORS_FOR_FLAGS( LogFilteredData::Visibility )
+Q_DECLARE_METATYPE( LogFilteredData::Visibility )
 
 #endif

--- a/src/logdata/include/data/logfiltereddata.h
+++ b/src/logdata/include/data/logfiltereddata.h
@@ -116,6 +116,8 @@ class LogFilteredData : public AbstractLogData {
     // Delete the mark present on the passed line or do nothing if there is
     // none.
     void deleteMark( LineNumber line );
+    // Toggle presence of the mark on the passed line.
+    void toggleMark( LineNumber line, QChar mark = {} );
     // Completely clear the marks list.
     void clearMarks();
     // Get all marked lines
@@ -158,6 +160,9 @@ class LogFilteredData : public AbstractLogData {
 
     void doAttachReader() const override;
     void doDetachReader() const override;
+
+    // Insert new mark into filteredItemsCache_.
+    void updateCacheWithMark( uint32_t index, LineNumber line );
 
     // Returns whether the line number passed is in our list of matching ones.
     bool isLineMatched( LineNumber lineNumber ) const;
@@ -250,11 +255,11 @@ class LogFilteredData::FilteredItem {
     void add( LineType type )
     { type_ |= type; }
 
-    // Returns whether any type-flag is left.
-    bool remove( LineType type )
+    // Returns the new type flags.
+    LineType remove( LineType type )
     {
         type_ &= ~type;
-        return !!type_;
+        return type_;
     }
 
     bool operator <( const LogFilteredData::FilteredItem& other ) const

--- a/src/logdata/include/data/marks.h
+++ b/src/logdata/include/data/marks.h
@@ -83,6 +83,9 @@ class Marks {
     // none.
     // Returns the index at which the mark was deleted.
     uint32_t deleteMark( LineNumber line );
+    // Toggle presence of the mark on the passed line.
+    // Returns true if a mark is added, false if it is removed.
+    bool toggleMark( LineNumber line, QChar mark, uint32_t &index );
     // Get the line marked identified by the index (in this list) passed.
     LineNumber getLineMarkedByIndex( int index ) const
     { return marks_[index].lineNumber(); }

--- a/src/logdata/src/marks.cpp
+++ b/src/logdata/src/marks.cpp
@@ -104,6 +104,27 @@ uint32_t Marks::deleteMark( LineNumber line )
     return index;
 }
 
+bool Marks::toggleMark( LineNumber line, QChar mark, uint32_t &index )
+{
+    // 'mark' is not used yet
+    Q_UNUSED(mark);
+
+    // Look for the index immediately before
+    if ( lookupLineNumber( marks_, line, index ) )
+    {
+        marks_.erase( marks_.begin() + index );
+        return false;
+    }
+    else
+    {
+        // If a mark is not already set for this line
+        LOG(logDEBUG) << "Inserting mark at line " << line
+            << " (index " << index << ")";
+        marks_.emplace( marks_.begin() + index,  line );
+        return true;
+    }
+}
+
 void Marks::clear()
 {
     marks_.clear();

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -53,10 +53,10 @@
 #include "quickfindmux.h"
 #include "viewtools.h"
 #include "data/linetypes.h"
+#include "data/abstractlogdata.h"
 
 class QMenu;
 class QAction;
-class AbstractLogData;
 
 class LineChunk
 {
@@ -213,10 +213,9 @@ class AbstractLogView :
     void wheelEvent( QWheelEvent* wheelEvent ) override;
     bool event( QEvent * e ) override;
 
-    // Must be implemented to return wether the line number is
-    // a match, a mark or just a normal line (used for coloured bullets)
-    enum LineType { Normal, Marked, Match };
-    virtual LineType lineType( LineNumber lineNumber ) const = 0;
+    // Must be implemented to return what LineType the line number is
+    // (used for coloured bullets)
+    virtual AbstractLogData::LineType lineType( LineNumber lineNumber ) const = 0;
 
     // Line number to display for line at the given index
     virtual LineNumber displayLineNumber( LineNumber lineNumber ) const;

--- a/src/ui/include/filteredview.h
+++ b/src/ui/include/filteredview.h
@@ -59,7 +59,7 @@ class FilteredView : public AbstractLogView
     void setVisibility( Visibility visi );
 
   protected:
-    LineType lineType(LineNumber lineNumber ) const override;
+    LogFilteredData::LineType lineType( LineNumber lineNumber ) const override;
 
     // Number of the filtered line relative to the unfiltered source
     LineNumber displayLineNumber(LineNumber lineNumber ) const override;

--- a/src/ui/include/logmainview.h
+++ b/src/ui/include/logmainview.h
@@ -61,7 +61,7 @@ class LogMainView : public AbstractLogView
 
   protected:
     // Implements the virtual function
-    LineType lineType( LineNumber lineNumber ) const override;
+    LogData::LineType lineType( LineNumber lineNumber ) const override;
 
     void keyPressEvent( QKeyEvent* keyEvent ) override;
 

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1620,6 +1620,7 @@ void AbstractLogView::drawTextArea( QPaintDevice* paint_device, int32_t delta_y 
     static const QBrush normalBulletBrush = QBrush( Qt::white );
     static const QBrush matchBulletBrush = QBrush( Qt::red );
     static const QBrush markBrush = QBrush( "dodgerblue" );
+    static const QBrush markedMatchBrush = QBrush( "maroon" );
 
     static const int SEPARATOR_WIDTH = 1;
     static const qreal BULLET_AREA_WIDTH = 11;
@@ -1829,8 +1830,9 @@ void AbstractLogView::drawTextArea( QPaintDevice* paint_device, int32_t delta_y 
         const qreal middleXLine = BULLET_AREA_WIDTH / 2;
         const qreal middleYLine = yPos + ( fontHeight / 2 );
 
-        const LineType line_type = lineType( line_index );
-        if ( line_type == Marked ) {
+        using LineTypeFlags = AbstractLogData::LineTypeFlags;
+        const AbstractLogData::LineType line_type = lineType( line_index );
+        if ( line_type.testFlag( LineTypeFlags::Mark ) ) {
             // A pretty arrow if the line is marked
             const QPointF points[ 7 ] = {
                 QPointF( 1, middleYLine - 2 ),
@@ -1842,17 +1844,17 @@ void AbstractLogView::drawTextArea( QPaintDevice* paint_device, int32_t delta_y 
                 QPointF( 1, middleYLine + 2 ),
             };
 
-            painter.setBrush( markBrush );
+            painter.setBrush( line_type.testFlag( LineTypeFlags::Match ) ? markedMatchBrush : markBrush );
             painter.drawPolygon( points, 7 );
         }
         else {
             // For pretty circles
             painter.setRenderHint( QPainter::Antialiasing );
 
-            if ( lineType( line_index ) == Match )
-                painter.setBrush( matchBulletBrush );
-            else
-                painter.setBrush( normalBulletBrush );
+            QBrush brush = normalBulletBrush;;
+            if ( line_type.testFlag( LineTypeFlags::Match ) )
+                brush = matchBulletBrush;
+            painter.setBrush( brush );
             painter.drawEllipse( middleXLine - circleSize, middleYLine - circleSize, circleSize * 2,
                                  circleSize * 2 );
         }

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -441,10 +441,7 @@ void CrawlerWidget::updateLineNumberHandler( LineNumber line )
 void CrawlerWidget::markLineFromMain( LineNumber line )
 {
     if ( line < logData_->getNbLine() ) {
-        if ( logFilteredData_->isLineMarked( line ) )
-            logFilteredData_->deleteMark( line );
-        else
-            logFilteredData_->addMark( line );
+        logFilteredData_->toggleMark( line );
 
         // Recompute the content of both window.
         filteredView->updateData();
@@ -462,10 +459,7 @@ void CrawlerWidget::markLineFromFiltered( LineNumber line )
 {
     if ( line < logFilteredData_->getNbLine() ) {
         const auto line_in_file = logFilteredData_->getMatchingLineNumber( line );
-        if ( logFilteredData_->lineTypeByIndex( line ).testFlag( LogFilteredData::LineTypeFlags::Mark ) )
-            logFilteredData_->deleteMark( line_in_file );
-        else
-            logFilteredData_->addMark( line_in_file );
+        logFilteredData_->toggleMark( line_in_file );
 
         // Recompute the content of both window.
         filteredView->updateData();

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -462,7 +462,7 @@ void CrawlerWidget::markLineFromFiltered( LineNumber line )
 {
     if ( line < logFilteredData_->getNbLine() ) {
         const auto line_in_file = logFilteredData_->getMatchingLineNumber( line );
-        if ( logFilteredData_->isLineMarked( line_in_file ) )
+        if ( logFilteredData_->lineTypeByIndex( line ).testFlag( LogFilteredData::LineTypeFlags::Mark ) )
             logFilteredData_->deleteMark( line_in_file );
         else
             logFilteredData_->addMark( line_in_file );
@@ -647,8 +647,7 @@ void CrawlerWidget::searchTextChangeHandler( QString )
 void CrawlerWidget::changeFilteredViewVisibility( int index )
 {
     QStandardItem* item = visibilityModel_->item( index );
-    FilteredView::Visibility visibility
-        = static_cast<FilteredView::Visibility>( item->data().toInt() );
+    auto visibility = item->data().value<FilteredView::Visibility>();
 
     filteredView->setVisibility( visibility );
 
@@ -727,27 +726,28 @@ void CrawlerWidget::setup()
     logMainView->useNewFiltering( logFilteredData_ );
 
     // Construct the visibility button
+    using VisibilityFlags = LogFilteredData::VisibilityFlags;
     visibilityModel_ = new QStandardItemModel( this );
 
     QStandardItem* marksAndMatchesItem = new QStandardItem( tr( "Marks and matches" ) );
     QPixmap marksAndMatchesPixmap( 16, 10 );
     marksAndMatchesPixmap.fill( Qt::gray );
     marksAndMatchesItem->setIcon( QIcon( marksAndMatchesPixmap ) );
-    marksAndMatchesItem->setData( QVariant::fromValue( FilteredView::Visibility::MarksAndMatches ) );
+    marksAndMatchesItem->setData( QVariant::fromValue( VisibilityFlags::Marks | VisibilityFlags::Matches ) );
     visibilityModel_->appendRow( marksAndMatchesItem );
 
     QStandardItem* marksItem = new QStandardItem( tr( "Marks" ) );
     QPixmap marksPixmap( 16, 10 );
     marksPixmap.fill( Qt::blue );
     marksItem->setIcon( QIcon( marksPixmap ) );
-    marksItem->setData( QVariant::fromValue( FilteredView::Visibility::MarksOnly ) );
+    marksItem->setData( QVariant::fromValue<FilteredView::Visibility>( VisibilityFlags::Marks ) );
     visibilityModel_->appendRow( marksItem );
 
     QStandardItem* matchesItem = new QStandardItem( tr( "Matches" ) );
     QPixmap matchesPixmap( 16, 10 );
     matchesPixmap.fill( Qt::red );
     matchesItem->setIcon( QIcon( matchesPixmap ) );
-    matchesItem->setData( QVariant::fromValue( FilteredView::Visibility::MatchesOnly ) );
+    matchesItem->setData( QVariant::fromValue<FilteredView::Visibility>( VisibilityFlags::Matches ) );
     visibilityModel_->appendRow( matchesItem );
 
     auto* visibilityView = new QListView( this );

--- a/src/ui/src/filteredview.cpp
+++ b/src/ui/src/filteredview.cpp
@@ -62,16 +62,10 @@ void FilteredView::setVisibility( Visibility visi )
 }
 
 // For the filtered view, a line is always matching!
-AbstractLogView::LineType FilteredView::lineType( LineNumber lineNumber ) const
+AbstractLogData::LineType FilteredView::lineType( LineNumber lineNumber ) const
 {
-    const auto line_in_file = logFilteredData_->getMatchingLineNumber( lineNumber );
-
-    if ( logFilteredData_->isLineMarked( line_in_file ) ) {
-        return Marked;
-    }
-    else {
-        return Match;
-    }
+    // line in filteredview corresponds to index
+    return logFilteredData_->lineTypeByIndex( lineNumber );
 }
 
 LineNumber FilteredView::displayLineNumber( LineNumber lineNumber ) const
@@ -99,17 +93,18 @@ void FilteredView::keyPressEvent( QKeyEvent* keyEvent )
         switch ( keyEvent->key() ) {
             case Qt::Key_BracketLeft:
             {
+                using LineTypeFlags = LogFilteredData::LineTypeFlags;
                 auto i = getViewPosition() - 1_lcount;
                 bool foundMark = false;
                 for (; i != 0_lnum; --i ) {
-                    if ( lineType( i ) == Marked ) {
+                    if ( lineType( i ).testFlag( LineTypeFlags::Mark ) ) {
                         foundMark = true;
                         break;
                     }
                 }
 
                 if ( !foundMark ) {
-                    foundMark = lineType( i ) == Marked;
+                    foundMark = lineType( i ).testFlag( LineTypeFlags::Mark );
                 }
 
                 if ( foundMark ) {
@@ -123,7 +118,7 @@ void FilteredView::keyPressEvent( QKeyEvent* keyEvent )
             {
                 const auto nbLines = logFilteredData_->getNbLine();
                 for ( auto i = getViewPosition() + 1_lcount; i < nbLines; ++i ) {
-                    if ( lineType( i ) == Marked ) {
+                    if ( lineType( i ).testFlag( LogFilteredData::LineTypeFlags::Mark ) ) {
                         selectAndDisplayLine( i );
                         break;
                     }

--- a/src/ui/src/logmainview.cpp
+++ b/src/ui/src/logmainview.cpp
@@ -70,21 +70,12 @@ void LogMainView::useNewFiltering( LogFilteredData* filteredData )
         getOverview()->setFilteredData( filteredData_ );
 }
 
-AbstractLogView::LineType LogMainView::lineType(LineNumber lineNumber ) const
+AbstractLogData::LineType LogMainView::lineType( LineNumber lineNumber ) const
 {
-    if ( filteredData_ != nullptr ) {
-        LineType line_type;
-        if ( filteredData_->isLineMarked( lineNumber ) )
-            line_type = Marked;
-        else if ( filteredData_->isLineInMatchingList( lineNumber ) )
-            line_type = Match;
-        else
-            line_type = Normal;
-
-        return line_type;
+    if ( filteredData_ ) {
+        return filteredData_->lineTypeByLine( lineNumber );
     }
-    else
-        return Normal;
+    return AbstractLogData::LineTypeFlags::Plain;
 }
 
 void LogMainView::keyPressEvent( QKeyEvent* keyEvent )

--- a/src/ui/src/overview.cpp
+++ b/src/ui/src/overview.cpp
@@ -112,11 +112,11 @@ void Overview::recalculatesLines()
         if ( linesInFile_.get() > 0 ) {
             const auto nbLines = logFilteredData_->getNbLine();
             for ( auto i = 0_lnum; i < nbLines; ++i ) {
-                LogFilteredData::FilteredLineType line_type =
-                    logFilteredData_->filteredLineTypeByIndex( i );
+                LogFilteredData::LineType line_type =
+                    logFilteredData_->lineTypeByIndex( i );
                 const auto line = logFilteredData_->getMatchingLineNumber( i );
                 const auto position = static_cast<int>( (qint64)(line.get()) * height_ / linesInFile_.get() );
-                if ( line_type.testFlag( LogFilteredData::FilteredLineTypeFlags::Match ) ) {
+                if ( line_type.testFlag( LogFilteredData::LineTypeFlags::Match ) ) {
                     if ( ( ! matchLines_.empty() ) && matchLines_.back().position() == position ) {
                         // If the line is already there, we increase its weight
                         matchLines_.back().load();


### PR DESCRIPTION
Fixes (and implements the change proposed in) #89.
I found the marron (dark red) arrow stylistically more pleasing than a violet one for lines that are simultaneously marked and matched.

One more thing that needed changing, which did not become apparent in #89, is adding "missing" flags on the `filteredItemsCache_` when a visibility-mode is inactive (commit 9c3e926d18c88288030bdcbc6485743a11868154).
This issue manifested, for example, in just the regular red circle showing in the filtered view when only viewing matches (not "MarksAndMatches") and making a new search. Even if the line is marked, which should display a maroon arrow, it displayed a red circle, since `insertNewMatches()` simply sets `LineTypeFlag::Match`.