### PR TITLE
Fix font size dialog

### DIFF
--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -206,6 +206,8 @@ void OptionsDialog::updateDialogFromConfig()
     if ( familyIndex != -1 )
         fontFamilyBox->setCurrentIndex( familyIndex );
 
+    updateFontSize(fontInfo.family());
+
     int sizeIndex = fontSizeBox->findText( QString::number( fontInfo.pointSize() ) );
     if ( sizeIndex != -1 )
         fontSizeBox->setCurrentIndex( sizeIndex );


### PR DESCRIPTION
Noticed that the font size combo box was empty and that font size wasn't saved.