### PR TITLE
Add drop-down menu with predefined filters

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(ui STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersmenu.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightedmatch.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/predefinedfilters.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/predefinedfiltersdialog.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/infoline.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/pathline.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/logmainview.h
@@ -42,6 +43,7 @@ add_library(ui STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include/highlighteredit.ui
         ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersetedit.ui
         ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersdialog.ui
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/predefinedfiltersdialog.ui
         ${CMAKE_CURRENT_SOURCE_DIR}/include/optionsdialog.ui
 
         ${CMAKE_CURRENT_SOURCE_DIR}/src/abstractlogview.cpp
@@ -52,6 +54,7 @@ add_library(ui STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/src/highlightersetedit.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/highlighterset.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/predefinedfilters.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/predefinedfiltersdialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/infoline.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/pathline.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/logmainview.cpp

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(ui STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include/highlighterset.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersmenu.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightedmatch.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/predefinedfilters.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/infoline.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/pathline.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/logmainview.h
@@ -50,6 +51,7 @@ add_library(ui STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/src/highlighteredit.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/highlightersetedit.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/highlighterset.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/predefinedfilters.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/infoline.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/pathline.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/logmainview.cpp

--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -56,11 +56,12 @@
 #include "data/logdata.h"
 #include "data/logfiltereddata.h"
 #include "filteredview.h"
+#include "iconloader.h"
 #include "logmainview.h"
 #include "overview.h"
+#include "predefinedfilters.h"
 #include "signalmux.h"
 #include "viewinterface.h"
-#include "iconloader.h"
 
 class InfoLine;
 class QuickFindPattern;
@@ -109,6 +110,9 @@ class CrawlerWidget : public QSplitter,
 
     // Get content of search line
     QString currentSearchLineEditText() const;
+
+    // Reload predefined filters after changing settings
+    void reloadPredefinedFilters() const;
 
   public slots:
     // Stop the asynchoronous loading of the file if one is in progress
@@ -309,6 +313,7 @@ class CrawlerWidget : public QSplitter,
     QToolButton* useRegexpButton;
     QToolButton* searchRefreshButton;
     OverviewWidget* overviewWidget_;
+    PredefinedFiltersComboBox* predefinedFilters;
 
     // Default palette to be remembered
     QPalette searchInfoLineDefaultPalette;

--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -104,6 +104,12 @@ class CrawlerWidget : public QSplitter,
     // Returns whether follow is enabled in this crawler
     bool isFollowEnabled() const;
 
+    // Set content of search line
+    void setSearchLineEditText( const QString& text );
+
+    // Get content of search line
+    QString currentSearchLineEditText() const;
+
   public slots:
     // Stop the asynchoronous loading of the file if one is in progress
     // The file is identified by the view attached to it.

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -113,6 +113,7 @@ class MainWindow : public QMainWindow {
     void openClipboard();
     void openUrl();
     void editHighlighters();
+    void editPredefinedFilters();
     void options();
     void about();
     void aboutQt();
@@ -253,6 +254,7 @@ class MainWindow : public QMainWindow {
     QAction* showDocumentationAction;
     QAction* aboutAction;
     QAction* aboutQtAction;
+    QAction* predefinedFiltersDialogAction;
     QAction* reportIssueAction;
     QAction* generateDumpAction;
     QActionGroup* encodingGroup;

--- a/src/ui/include/predefinedfilters.h
+++ b/src/ui/include/predefinedfilters.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2009, 2010, 2011, 2013, 2014, 2015 Nicolas Bonnefon
+ * and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright (C) 2016 -- 2019 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PREDEFINEDFILTERS_H_
+#define PREDEFINEDFILTERS_H_
+
+#include <QComboBox>
+#include <qwidget.h>
+
+#include "crawlerwidget.h"
+#include "persistable.h"
+
+// Represents collection of filters read from settings file.
+class PredefinedFiltersCollection final : public Persistable<PredefinedFiltersCollection> {
+  public:
+    static const char* persistableName()
+    {
+        return "PredefinedFiltersCollection";
+    }
+
+    QMap<QString, QString> getSyncedFilters();
+    QMap<QString, QString> getFilters() const;
+
+    void retrieveFromStorage( QSettings& settings );
+
+  private:
+    static constexpr int PredefinedFiltersCollection_VERSION = 1;
+
+    QMap<QString, QString> filters;
+};
+
+class PredefinedFiltersComboBox final : public QComboBox {
+    Q_OBJECT
+
+  public:
+    PredefinedFiltersComboBox( CrawlerWidget* p );
+
+    PredefinedFiltersComboBox( const PredefinedFiltersComboBox& other ) = delete;
+    PredefinedFiltersComboBox( PredefinedFiltersComboBox&& other ) noexcept = delete;
+    PredefinedFiltersComboBox& operator=( const PredefinedFiltersComboBox& other ) = delete;
+    PredefinedFiltersComboBox& operator=( PredefinedFiltersComboBox&& other ) = delete;
+
+  private:
+    CrawlerWidget* parent;
+    PredefinedFiltersCollection filtersCollection;
+
+    QStandardItemModel* model;
+
+    void setup();
+
+    void setTitle( const QString& title );
+    void insertFilters( const QMap<QString, QString>& filters );
+    void connectFilters( const QMap<QString, QString>& filters );
+};
+
+#endif

--- a/src/ui/include/predefinedfilters.h
+++ b/src/ui/include/predefinedfilters.h
@@ -41,43 +41,50 @@
 #define PREDEFINEDFILTERS_H_
 
 #include <QComboBox>
+#include <QStandardItemModel>
 #include <qwidget.h>
 
-#include "crawlerwidget.h"
 #include "persistable.h"
 
 // Represents collection of filters read from settings file.
 class PredefinedFiltersCollection final : public Persistable<PredefinedFiltersCollection> {
   public:
+    using Collection = QMap<QString, QString>;
+    using CollectionIterator = QMapIterator<QString, QString>;
+
     static const char* persistableName()
     {
-        return "PredefinedFiltersCollection";
+        return "PredefinedFiltersCollectin";
     }
 
-    QMap<QString, QString> getSyncedFilters();
-    QMap<QString, QString> getFilters() const;
+    Collection getSyncedFilters();
+    Collection getFilters() const;
 
     void retrieveFromStorage( QSettings& settings );
+    void saveToStorage( QSettings& settings ) const;
+    void saveToStorage( const Collection& filters );
 
   private:
     static constexpr int PredefinedFiltersCollection_VERSION = 1;
 
-    QMap<QString, QString> filters;
+    Collection filters;
 };
 
 class PredefinedFiltersComboBox final : public QComboBox {
     Q_OBJECT
 
   public:
-    PredefinedFiltersComboBox( CrawlerWidget* p );
+    PredefinedFiltersComboBox( QWidget* crawler );
 
     PredefinedFiltersComboBox( const PredefinedFiltersComboBox& other ) = delete;
     PredefinedFiltersComboBox( PredefinedFiltersComboBox&& other ) noexcept = delete;
     PredefinedFiltersComboBox& operator=( const PredefinedFiltersComboBox& other ) = delete;
     PredefinedFiltersComboBox& operator=( PredefinedFiltersComboBox&& other ) = delete;
 
+    void populatePredefinedFilters();
+
   private:
-    CrawlerWidget* parent;
+    QWidget* crawlerWidget;
     PredefinedFiltersCollection filtersCollection;
 
     QStandardItemModel* model;
@@ -85,8 +92,8 @@ class PredefinedFiltersComboBox final : public QComboBox {
     void setup();
 
     void setTitle( const QString& title );
-    void insertFilters( const QMap<QString, QString>& filters );
-    void connectFilters( const QMap<QString, QString>& filters );
+    void insertFilters( const PredefinedFiltersCollection::Collection& filters );
+    void connectFilters( const PredefinedFiltersCollection::Collection& filters );
 };
 
 #endif

--- a/src/ui/include/predefinedfiltersdialog.h
+++ b/src/ui/include/predefinedfiltersdialog.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2009, 2010, 2011, 2013, 2014, 2015 Nicolas Bonnefon
+ * and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright (C) 2016 -- 2019 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PREDEFINEDFILTERSDIALOG_H_
+#define PREDEFINEDFILTERSDIALOG_H_
+
+#include "predefinedfilters.h"
+#include "predefinedfiltersdialog.h"
+#include "ui_predefinedfiltersdialog.h"
+
+#include <QDialog>
+
+class PredefinedFiltersDialog : public QDialog, public Ui::PredefinedFiltersDialog {
+    Q_OBJECT
+
+  public:
+    explicit PredefinedFiltersDialog( QWidget* parent = nullptr );
+
+  private:
+    PredefinedFiltersCollection::Collection filters;
+
+    void populateFiltersTable() const;
+    void saveSettings();
+
+  private slots:
+    void addFilter() const;
+    void removeFilter() const;
+
+    void resolveStandardButton( QAbstractButton* button );
+
+  signals:
+    void optionsChanged();
+};
+
+#endif

--- a/src/ui/include/predefinedfiltersdialog.ui
+++ b/src/ui/include/predefinedfiltersdialog.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PredefinedFiltersDialog</class>
+ <widget class="QDialog" name="PredefinedFiltersDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Predefined Filters</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,0">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <item>
+    <widget class="QTableWidget" name="filtersTableWidget"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="addFilterButton">
+       <property name="toolTip">
+        <string>New Filter</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../app/klogg.qrc">
+         <normaloff>:/images/icons8-plus-16.png</normaloff>:/images/icons8-plus-16.png
+        </iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="removeFilterButton">
+       <property name="toolTip">
+        <string>Remove Filter</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../app/klogg.qrc">
+         <normaloff>:/images/icons8-minus-16.png</normaloff>:/images/icons8-minus-16.png
+        </iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../app/klogg.qrc"/>
+  <include location="../../app/klogg.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -63,6 +63,7 @@
 #include "configuration.h"
 #include "infoline.h"
 #include "overview.h"
+#include "predefinedfilters.h"
 #include "quickfindpattern.h"
 #include "quickfindwidget.h"
 #include "savedsearches.h"
@@ -177,6 +178,16 @@ absl::optional<int> CrawlerWidget::encodingMib() const
 bool CrawlerWidget::isFollowEnabled() const
 {
     return logMainView->isFollowEnabled();
+}
+
+void CrawlerWidget::setSearchLineEditText( const QString& text )
+{
+    searchLineEdit->setCurrentText( text );
+}
+
+QString CrawlerWidget::currentSearchLineEditText() const
+{
+    return searchLineEdit->currentText();
 }
 
 QString CrawlerWidget::encodingText() const
@@ -902,6 +913,8 @@ void CrawlerWidget::setup()
     stopButton->setVisible( false );
     stopButton->setContentsMargins( 2, 2, 2, 2 );
 
+    auto* predefinedFilters = new PredefinedFiltersComboBox( this );
+
     auto* searchLineLayout = new QHBoxLayout;
     searchLineLayout->setContentsMargins( 2, 2, 2, 2 );
 
@@ -913,6 +926,7 @@ void CrawlerWidget::setup()
     searchLineLayout->addWidget( stopButton );
     searchLineLayout->addWidget( searchRefreshButton );
     searchLineLayout->addWidget( searchInfoLine );
+    searchLineLayout->addWidget( predefinedFilters );
 
     // Construct the bottom window
     auto* bottomMainLayout = new QVBoxLayout;

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -190,6 +190,11 @@ QString CrawlerWidget::currentSearchLineEditText() const
     return searchLineEdit->currentText();
 }
 
+void CrawlerWidget::reloadPredefinedFilters() const
+{
+    predefinedFilters->populatePredefinedFilters();
+}
+
 QString CrawlerWidget::encodingText() const
 {
     return encoding_text_;
@@ -578,6 +583,8 @@ void CrawlerWidget::applyConfiguration()
     if ( isFollowEnabled() ) {
         changeDataStatus( DataStatus::OLD_DATA );
     }
+
+    reloadPredefinedFilters();
 }
 
 void CrawlerWidget::enteringQuickFind()
@@ -913,7 +920,7 @@ void CrawlerWidget::setup()
     stopButton->setVisible( false );
     stopButton->setContentsMargins( 2, 2, 2, 2 );
 
-    auto* predefinedFilters = new PredefinedFiltersComboBox( this );
+    predefinedFilters = new PredefinedFiltersComboBox( this );
 
     auto* searchLineLayout = new QHBoxLayout;
     searchLineLayout->setContentsMargins( 2, 2, 2, 2 );

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -87,6 +87,8 @@
 #include "log.h"
 #include "openfilehelper.h"
 #include "optionsdialog.h"
+#include "predefinedfilters.h"
+#include "predefinedfiltersdialog.h"
 #include "readablesize.h"
 #include "recentfiles.h"
 #include "styles.h"
@@ -444,6 +446,11 @@ void MainWindow::createActions()
              [this]( auto ) { this->selectOpenedFile(); } );
     selectOpenFileAction->setShortcuts( QList<QKeySequence>()
                                         << QKeySequence( Qt::SHIFT | Qt::CTRL | Qt::Key_O ) );
+
+    predefinedFiltersDialogAction = new QAction( tr( "Configure predefined filters" ), this );
+    predefinedFiltersDialogAction->setStatusTip( tr( "Show dialog to configure filters" ) );
+    connect( predefinedFiltersDialogAction, &QAction::triggered,
+             [ this ]( auto ) { this->editPredefinedFilters(); } );
 }
 
 void MainWindow::loadIcons()
@@ -506,6 +513,8 @@ void MainWindow::createMenus()
     highlightersMenu = toolsMenu->addMenu( "Highlighters" );
     connect( highlightersMenu, &QMenu::aboutToShow,
              [this]() { setCurrentHighlighterAction( highlightersActionGroup ); } );
+
+    toolsMenu->addAction( predefinedFiltersDialogAction );
 
     toolsMenu->addSeparator();
     toolsMenu->addAction( optionsAction );
@@ -878,6 +887,17 @@ void MainWindow::editHighlighters()
     signalMux_.connect( &dialog, SIGNAL( optionsChanged() ), SLOT( applyConfiguration() ) );
 
     connect( &dialog, &HighlightersDialog::optionsChanged, [this]() { updateHighlightersMenu(); } );
+
+    dialog.exec();
+    signalMux_.disconnect( &dialog, SIGNAL( optionsChanged() ), SLOT( applyConfiguration() ) );
+}
+
+// Opens dialog to configure predefined filters
+void MainWindow::editPredefinedFilters()
+{
+    PredefinedFiltersDialog dialog( this );
+
+    signalMux_.connect( &dialog, SIGNAL( optionsChanged() ), SLOT( applyConfiguration() ) );
 
     dialog.exec();
     signalMux_.disconnect( &dialog, SIGNAL( optionsChanged() ), SLOT( applyConfiguration() ) );

--- a/src/ui/src/predefinedfilters.cpp
+++ b/src/ui/src/predefinedfilters.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2009, 2010 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright (C) 2019 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "predefinedfilters.h"
+#include "crawlerwidget.h"
+#include "log.h"
+#include <qnamespace.h>
+#include <qstandarditemmodel.h>
+
+void PredefinedFiltersCollection::retrieveFromStorage( QSettings& settings )
+{
+    LOG( logDEBUG ) << "PredefinedFiltersCollection::retrieveFromStorage";
+
+    if ( settings.contains( "PredefinedFiltersCollection/version" ) ) {
+        settings.beginGroup( "PredefinedFiltersCollection" );
+        if ( settings.value( "version" ).toInt() <= PredefinedFiltersCollection_VERSION ) {
+            filters.clear();
+
+            int size = settings.beginReadArray( "filters" );
+
+            for ( int i = 0; i < size; ++i ) {
+                settings.setArrayIndex( i );
+
+                filters.insert( QString( settings.value( "name" ).toString() ),
+                                QString( settings.value( "filter" ).toString() ) );
+            }
+        }
+        else {
+            LOG( logERROR ) << "Unknown version of PredefinedFiltersCollection, ignoring it...";
+        }
+        settings.endGroup();
+    }
+}
+
+QMap<QString, QString> PredefinedFiltersCollection::getFilters() const
+{
+    return this->filters;
+}
+
+QMap<QString, QString> PredefinedFiltersCollection::getSyncedFilters()
+{
+    return this->getSynced().getFilters();
+}
+
+PredefinedFiltersComboBox::PredefinedFiltersComboBox( CrawlerWidget* p )
+    : parent( p )
+{
+    setup();
+}
+
+void PredefinedFiltersComboBox::setup()
+{
+    const auto filters = filtersCollection.getSyncedFilters();
+
+    this->setFocusPolicy( Qt::NoFocus );
+
+    model = new QStandardItemModel();
+
+    setTitle( "Predefined filters" );
+    insertFilters( filters );
+
+    this->setModel( model );
+
+    connectFilters( filters );
+}
+
+void PredefinedFiltersComboBox::setTitle( const QString& title )
+{
+    auto* titleItem = new QStandardItem( title );
+    titleItem->setFlags( titleItem->flags() & ~Qt::ItemIsSelectable );
+    model->insertRow( 0, titleItem );
+}
+
+void PredefinedFiltersComboBox::insertFilters( const QMap<QString, QString>& filters )
+{
+    auto i = model->rowCount();
+
+    QMapIterator<QString, QString> iter( filters );
+
+    while ( iter.hasNext() ) {
+        iter.next();
+        auto* item = new QStandardItem( iter.key() );
+
+        item->setFlags( Qt::ItemIsUserCheckable | Qt::ItemIsEnabled );
+        item->setData( Qt::Unchecked, Qt::CheckStateRole );
+
+        model->insertRow( i++, item );
+    }
+}
+
+void PredefinedFiltersComboBox::connectFilters( const QMap<QString, QString>& filters )
+{
+    connect( model, &QStandardItemModel::itemChanged, [ = ]( const QStandardItem* changed_item ) {
+        (void)changed_item;
+
+        const auto size = model->rowCount();
+
+        /* If multiple filters are selected connect those with "|" */
+
+        QString filter;
+        parent->setSearchLineEditText( "" );
+
+        for ( auto j = 0; j < size; ++j ) {
+            const auto item = model->item( j );
+
+            if ( item->checkState() == Qt::Checked ) {
+                const auto new_filter = filters.find( item->text() );
+
+                if ( filters.end() != new_filter ) {
+                    auto current_filter = parent->currentSearchLineEditText();
+
+                    if ( current_filter != "" )
+                        current_filter += "|";
+
+                    parent->setSearchLineEditText( current_filter + new_filter.value() );
+                }
+            }
+        }
+    } );
+}

--- a/src/ui/src/predefinedfiltersdialog.cpp
+++ b/src/ui/src/predefinedfiltersdialog.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2009, 2010 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright (C) 2019 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "predefinedfiltersdialog.h"
+#include "log.h"
+#include "predefinedfilters.h"
+#include <qdialogbuttonbox.h>
+#include <qwindowdefs.h>
+
+#include <set>
+
+PredefinedFiltersDialog::PredefinedFiltersDialog( QWidget* parent )
+    : QDialog( parent )
+{
+    setupUi( this );
+
+    filters = PredefinedFiltersCollection::getSynced().getFilters();
+
+    populateFiltersTable();
+
+    connect( addFilterButton, &QToolButton::clicked, this, &PredefinedFiltersDialog::addFilter );
+    connect( removeFilterButton, &QToolButton::clicked, this,
+             &PredefinedFiltersDialog::removeFilter );
+
+    connect( buttonBox, &QDialogButtonBox::clicked, this,
+             &PredefinedFiltersDialog::resolveStandardButton );
+}
+
+void PredefinedFiltersDialog::populateFiltersTable() const
+{
+    filtersTableWidget->clear();
+
+    filtersTableWidget->setRowCount( filters.size() );
+    filtersTableWidget->setColumnCount( 2 );
+
+    filtersTableWidget->setHorizontalHeaderLabels( QStringList() << "Filter name"
+                                                                 << "Pattern" );
+
+    PredefinedFiltersCollection::CollectionIterator iter( filters );
+    for ( int i = 0; iter.hasNext(); ++i ) {
+        iter.next();
+        filtersTableWidget->setItem( i, 0, new QTableWidgetItem( iter.key() ) );
+        filtersTableWidget->setItem( i, 1, new QTableWidgetItem( iter.value() ) );
+    }
+
+    filtersTableWidget->horizontalHeader()->setSectionResizeMode( 1, QHeaderView::Stretch );
+}
+
+void PredefinedFiltersDialog::saveSettings()
+{
+    const auto rows = filtersTableWidget->rowCount();
+
+    filters.clear();
+
+    for ( auto i = 0; i < rows; ++i ) {
+        if ( nullptr == filtersTableWidget->item( i, 0 )
+             || nullptr == filtersTableWidget->item( i, 1 ) )
+            continue;
+        const auto key = filtersTableWidget->item( i, 0 )->text();
+        const auto value = filtersTableWidget->item( i, 1 )->text();
+
+        if ( key != "" && value != "" )
+            filters.insert( key, value );
+    }
+
+    PredefinedFiltersCollection::getSynced().saveToStorage( filters );
+}
+
+void PredefinedFiltersDialog::addFilter() const
+{
+    filtersTableWidget->setRowCount( filtersTableWidget->rowCount() + 1 );
+}
+
+void PredefinedFiltersDialog::removeFilter() const
+{
+    filtersTableWidget->removeRow( filtersTableWidget->currentRow() );
+}
+
+void PredefinedFiltersDialog::resolveStandardButton( QAbstractButton* button )
+{
+    LOG( logDEBUG ) << "PredefinedFiltersDialog::resolveStandardButton";
+
+    const auto role = buttonBox->buttonRole( button );
+
+    if ( role == QDialogButtonBox::RejectRole ) {
+        reject();
+        return;
+    }
+
+    if ( role == QDialogButtonBox::AcceptRole ) {
+        saveSettings();
+        accept();
+    }
+    else if ( role == QDialogButtonBox::ApplyRole ) {
+        saveSettings();
+    }
+    else {
+        LOG( logERROR ) << "PredefinedFiltersDialog::resolveStandardButton unhandled role: "
+                        << role;
+        return;
+    }
+
+    emit optionsChanged();
+}


### PR DESCRIPTION
This implements issue discussed in: https://github.com/variar/klogg/issues/191.

New drop-down menu located next to "auto-refresh" button is introduced and it includes configurable filters which are automatically entered into search field.

To enable filter configuration new dialog was added in Tools -> Configure predefined filters.