### PR TITLE
fix: return deleted shortcut ReplaceSearch

### DIFF
--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -725,6 +725,8 @@ void AbstractLogView::doRegisterShortcuts()
     registerShortcut( ShortcutAction::LogViewAddToSearch, [ this ]() { addToSearch(); } );
     registerShortcut( ShortcutAction::LogViewExcludeFromSearch,
                       [ this ]() { excludeFromSearch(); } );
+    registerShortcut( ShortcutAction::LogViewReplaceSearch, [ this ]() { replaceSearch(); } );
+
     registerShortcut( ShortcutAction::LogViewSelectLinesUp, [ this ]() {
         auto newPosition = selectionCurrentEndPos_;
         if ( newPosition.line == 0_lcount ) {


### PR DESCRIPTION
I accidentally deleted one shortcut in the PR #542. I'm sorry. Please fix it