### PR TITLE
Shortcuts “Select lines up/down” No action name

### DIFF
--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -246,6 +246,9 @@ QString ShortcutAction::actionName( const std::string& action )
         shortcuts.emplace( LogViewExcludeFromSearch, "Exclude selection from search pattern " );
         shortcuts.emplace( LogViewReplaceSearch, "Replace search pattern with selection" );
 
+        shortcuts.emplace( LogViewSelectLinesUp, "Select lines down" );
+        shortcuts.emplace( LogViewSelectLinesDown, "Select lines up" );
+
         return shortcuts;
     }();
 


### PR DESCRIPTION
When I translated the file, I found that the newly added shortcut did not have an action name, so I added.

- **before modification**:
![image](https://user-images.githubusercontent.com/31587297/235239040-76e9376e-952f-4a4b-a589-d64ee4f75ef8.png)

- **after modification**:
![image](https://user-images.githubusercontent.com/31587297/235239089-6b2db1ed-4170-4a30-86e4-a7c1bc5e4dfe.png)
