### PR TITLE
feat: add a check for duplicate shortcuts to shortcut editor (348)

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -1040,22 +1040,22 @@
         <translation>Qt</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="568"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="569"/>
         <source>Klogg needs to be restarted to apply some changes. </source>
         <translation>Klogg needs to be restarted to apply some changes. </translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="681"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="682"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="682"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="683"/>
         <source>Primary shortcut</source>
         <translation>Primary shortcut</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="684"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="685"/>
         <source>Secondary shortcut</source>
         <translation>Secondary shortcut</translation>
     </message>

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -1040,22 +1040,22 @@
         <translation>Qt</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="520"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="568"/>
         <source>Klogg needs to be restarted to apply some changes. </source>
         <translation>Klogg needs to be restarted to apply some changes. </translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="625"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="681"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="626"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="682"/>
         <source>Primary shortcut</source>
         <translation>Primary shortcut</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="628"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="684"/>
         <source>Secondary shortcut</source>
         <translation>Secondary shortcut</translation>
     </message>

--- a/src/app/i18n/zh-CN.ts
+++ b/src/app/i18n/zh-CN.ts
@@ -1040,22 +1040,22 @@
         <translation>Qt</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="568"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="569"/>
         <source>Klogg needs to be restarted to apply some changes. </source>
         <translation type="unfinished">Klogg 需要关闭后重新打开才能应用这些更改. </translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="681"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="682"/>
         <source>Action</source>
         <translation type="unfinished">动作</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="682"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="683"/>
         <source>Primary shortcut</source>
         <translation type="unfinished">首选快捷键</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="684"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="685"/>
         <source>Secondary shortcut</source>
         <translation type="unfinished">备选快捷键</translation>
     </message>

--- a/src/app/i18n/zh-CN.ts
+++ b/src/app/i18n/zh-CN.ts
@@ -1040,22 +1040,22 @@
         <translation>Qt</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="520"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="568"/>
         <source>Klogg needs to be restarted to apply some changes. </source>
         <translation type="unfinished">Klogg 需要关闭后重新打开才能应用这些更改. </translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="625"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="681"/>
         <source>Action</source>
         <translation type="unfinished">动作</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="626"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="682"/>
         <source>Primary shortcut</source>
         <translation type="unfinished">首选快捷键</translation>
     </message>
     <message>
-        <location filename="../../ui/src/optionsdialog.cpp" line="628"/>
+        <location filename="../../ui/src/optionsdialog.cpp" line="684"/>
         <source>Secondary shortcut</source>
         <translation type="unfinished">备选快捷键</translation>
     </message>

--- a/src/ui/include/optionsdialog.h
+++ b/src/ui/include/optionsdialog.h
@@ -57,6 +57,9 @@ class KeySequencePresenter : public QWidget {
 
     QString keySequence() const;
 
+  Q_SIGNALS:
+    void edited();
+
   private Q_SLOTS:
     void showEditor();
 
@@ -87,6 +90,8 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
 
     void changeMainColor();
     void changeQfColor();
+
+    void checkShortcutsOnDuplicate() const;
 
   private:
     void setupTabs();

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -423,7 +423,7 @@ void OptionsDialog::checkShortcutsOnDuplicate() const
         shortcutsTable->item( shortcutRow, SECONDARY_COL )->setBackground( DEFAULT_BACKGROUND );
     }
 
-    std::unordered_map<QString, std::pair<int, int>> uniqueShortcuts;
+    std::unordered_map<std::string, std::pair<int, int>> uniqueShortcuts;
     for ( auto shortcutRow = 0; shortcutRow < shortcutsTable->rowCount(); ++shortcutRow ) {
 
         auto check = [ &uniqueShortcuts, shortcutRow, this ]( int ncol ) {
@@ -432,7 +432,8 @@ void OptionsDialog::checkShortcutsOnDuplicate() const
                                    ->keySequence();
 
             if ( !keySequence.isEmpty() ) {
-                if ( auto it = uniqueShortcuts.find( keySequence ); it != uniqueShortcuts.end() ) {
+                if ( auto it = uniqueShortcuts.find( keySequence.toStdString() );
+                     it != uniqueShortcuts.end() ) {
 
                     shortcutsTable->item( it->second.first, it->second.second )
                         ->setBackground( Qt::red );
@@ -444,8 +445,8 @@ void OptionsDialog::checkShortcutsOnDuplicate() const
                     return true;
                 }
 
-                uniqueShortcuts.insert(
-                    std::make_pair( keySequence, std::make_pair( shortcutRow, ncol ) ) );
+                uniqueShortcuts.try_emplace( keySequence.toStdString(),
+                                             std::make_pair( shortcutRow, ncol ) );
             }
 
             return false;

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -411,6 +411,54 @@ void OptionsDialog::changeQfColor()
     }
 }
 
+void OptionsDialog::checkShortcutsOnDuplicate() const
+{
+    static const int PRIMARY_COL = 1;
+    static const int SECONDARY_COL = 2;
+
+    for ( auto shortcutRow = 0; shortcutRow < shortcutsTable->rowCount(); ++shortcutRow ) {
+        static auto DEFAULT_BACKGROUND
+            = shortcutsTable->item( shortcutRow, PRIMARY_COL )->background();
+        shortcutsTable->item( shortcutRow, PRIMARY_COL )->setBackground( DEFAULT_BACKGROUND );
+        shortcutsTable->item( shortcutRow, SECONDARY_COL )->setBackground( DEFAULT_BACKGROUND );
+    }
+
+    std::unordered_map<QString, std::pair<int, int>> uniqueShortcuts;
+    for ( auto shortcutRow = 0; shortcutRow < shortcutsTable->rowCount(); ++shortcutRow ) {
+
+        auto check = [ &uniqueShortcuts, shortcutRow, this ]( int ncol ) {
+            auto keySequence = static_cast<KeySequencePresenter*>(
+                                   shortcutsTable->cellWidget( shortcutRow, ncol ) )
+                                   ->keySequence();
+
+            if ( !keySequence.isEmpty() ) {
+                if ( auto it = uniqueShortcuts.find( keySequence ); it != uniqueShortcuts.end() ) {
+
+                    shortcutsTable->item( it->second.first, it->second.second )
+                        ->setBackground( Qt::red );
+                    shortcutsTable->item( shortcutRow, ncol )->setBackground( Qt::red );
+
+                    buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
+                    buttonBox->button( QDialogButtonBox::Apply )->setEnabled( false );
+
+                    return true;
+                }
+
+                uniqueShortcuts.insert(
+                    std::make_pair( keySequence, std::make_pair( shortcutRow, ncol ) ) );
+            }
+
+            return false;
+        };
+
+        if ( check( PRIMARY_COL ) || check( SECONDARY_COL ) )
+            return;
+    }
+
+    buttonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
+    buttonBox->button( QDialogButtonBox::Apply )->setEnabled( true );
+}
+
 int OptionsDialog::updateTranslate()
 {
     auto mw = dynamic_cast<MainWindow*>( parent() );
@@ -585,6 +633,8 @@ void KeySequencePresenter::showEditor()
 
     if ( keyEditDialog.exec() == QDialog::Accepted ) {
         keySequenceLabel_->setText( editor->keySequence().toString() );
+        Q_EMIT edited(); // NOTE: it's important to emit this signal only after changing
+                         // \keySequenceLabel_'s text
     }
 }
 
@@ -613,11 +663,17 @@ void OptionsDialog::buildShortcutsTable()
 
         auto primaryKeySequence
             = new KeySequencePresenter( mapping.second.size() > 0 ? mapping.second[ 0 ] : "" );
+        shortcutsTable->setItem( currentRow, 1, new QTableWidgetItem );
         shortcutsTable->setCellWidget( currentRow, 1, primaryKeySequence );
+        connect( primaryKeySequence, &KeySequencePresenter::edited, this,
+                 &OptionsDialog::checkShortcutsOnDuplicate );
 
         auto secondaryKeySequence
             = new KeySequencePresenter( mapping.second.size() > 1 ? mapping.second[ 1 ] : "" );
+        shortcutsTable->setItem( currentRow, 2, new QTableWidgetItem );
         shortcutsTable->setCellWidget( currentRow, 2, secondaryKeySequence );
+        connect( secondaryKeySequence, &KeySequencePresenter::edited, this,
+                 &OptionsDialog::checkShortcutsOnDuplicate );
     }
 
     shortcutsTable->horizontalHeader()->setSectionResizeMode( QHeaderView::Stretch );


### PR DESCRIPTION
related to #348

I've implemented in that way, if a duplicate is found, conflicting cells are highlighted red and Apply and OK buttons are disabled
![GIF 5-12-2023 9-16-47 AM](https://github.com/variar/klogg/assets/22313821/e3361335-6c0d-4c20-8a61-695990fb2ef1)
