### PR TITLE
tr: fix build (#558)

### DIFF
--- a/src/app/klogg.qrc
+++ b/src/app/klogg.qrc
@@ -35,8 +35,8 @@
     <file>images/olddata_icon@2x.png</file>
     <file>images/regex.png</file>
     <file>i18n/Languages.xml</file>
-    <file>i18n/en.qm</file>
-    <file>i18n/zh-CN.qm</file>
+    <file alias="i18n/en.qm">i18n/en.ts</file>
+    <file alias="i18n/zh-CN.qm">i18n/zh-CN.ts</file>
 
     <file>fonts/DejaVuSansMono.ttf</file>
 </qresource>


### PR DESCRIPTION
After #558 I faced issues while building the project on my local computer:

```
9>------ Build started: Project: klogg, Configuration: RelWithDebInfo x64 ------
9>Build started 5/12/2023 8:17:00 AM.
9>Target ResolveProjectReferences:
9>  Target GetTargetPathWithTargetPlatformMoniker:
9>Target InitializeBuildStatus:
9>  Touching "klogg.dir\RelWithDebInfo\klogg.tlog\unsuccessfulbuild".
9>Target PreBuildEvent:
9>  Automatic MOC for target klogg
9>Target CustomBuild:
9>  "The build of 'C:\repos\repos\klogg\build_x64\CMakeFiles\e6cc725030852ad03b6e53eed1471f8a\qrc_documentation.cpp.rule' depends on 'C:\REPOS\REPOS\KLOGG\BUILD_X64\GENERATED\DOCUMENTATION.HTML' which is produced by the build of 'C:\repos\repos\klogg\build_x64\CMakeFiles\54559aadae52e986359e789dbb2e9f7c\documentation.html.rule'. The items cannot be built in parallel."
9>  Automatic RCC for klogg.qrc
9>
9>  AutoRcc subprocess error
9>  ------------------------
9>  The rcc process failed to compile
9>    "SRC:/src/app/klogg.qrc"
9>  into
9>    "SRC:/build_x64/src/app/klogg_autogen/include_Debug/EWIEGA46WW/qrc_klogg_CMAKE_.cpp"
9>
9>  Command
9>  -------
9>  C:/libs/vcpkg/installed/x64-windows/tools/qt5/bin/rcc.exe -name klogg -o C:/repos/repos/klogg/build_x64/src/app/klogg_autogen/include_Debug/EWIEGA46WW/qrc_klogg_CMAKE_.cpp C:/repos/repos/klogg/src/app/klogg.qrc
9>
9>  Output
9>  ------
9>  RCC: Error in 'C:/repos/repos/klogg/src/app/klogg.qrc': Cannot find file 'i18n/en.qm'
9>
9>
9>  C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(247,5): error MSB8066: Custom build for 'C:\repos\repos\klogg\build_x64\CMakeFiles\cff170e73b71181e07c5b30df548e320\qrc_klogg.cpp.rule;C:\repos\repos\klogg\build_x64\CMakeFiles\54559aadae52e986359e789dbb2e9f7c\documentation.html.rule;C:\repos\repos\klogg\build_x64\CMakeFiles\e6cc725030852ad03b6e53eed1471f8a\qrc_documentation.cpp.rule' exited with code 1.
9>Done building target "CustomBuild" in project "klogg.vcxproj" -- FAILED.
9>
9>Done building project "klogg.vcxproj" -- FAILED.
9>
9>Build FAILED.
9>
9>C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(247,5): error MSB8066: Custom build for 'C:\repos\repos\klogg\build_x64\CMakeFiles\cff170e73b71181e07c5b30df548e320\qrc_klogg.cpp.rule;C:\repos\repos\klogg\build_x64\CMakeFiles\54559aadae52e986359e789dbb2e9f7c\documentation.html.rule;C:\repos\repos\klogg\build_x64\CMakeFiles\e6cc725030852ad03b6e53eed1471f8a\qrc_documentation.cpp.rule' exited with code 1.
9>    0 Warning(s)
9>    1 Error(s)
```

After a little research I found similar problem discussion here: https://sourceforge.net/p/chessx/bugs/269/ and in the similar way I added aliases and it looks like it solved my problem.

@variar,  @nowhszh please have a look, maybe it's only my problem and I didnot configure something properly on my local machine?