### PR TITLE
feat: change visibility combobox to tabbar

### DIFF
--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -52,6 +52,7 @@
 #include <QSplitter>
 #include <QToolButton>
 #include <QVBoxLayout>
+#include <QTabBar>
 
 #include "colorlabelsmanager.h"
 #include "filteredview.h"
@@ -226,7 +227,7 @@ class CrawlerWidget : public QSplitter,
     // Called when the text on the search line is modified
     void searchTextChangeHandler( QString );
 
-    // Called when the user change the visibility combobox
+    // Called when the user change the visibility tabbar
     void changeFilteredViewVisibility( int index );
 
     // Called when the user add the string to the search
@@ -357,8 +358,7 @@ class CrawlerWidget : public QSplitter,
 
     OverviewWidget* overviewWidget_;
 
-    QComboBox* visibilityBox_;
-    QStandardItemModel* visibilityModel_;
+    QTabBar* visibilityBar_;
 
     PredefinedFiltersComboBox* predefinedFilters_;
 


### PR DESCRIPTION
Handle the feature request from myself: https://github.com/variar/klogg/issues/597

**Description**
Currently, we can choose the "Marks" option in the dropdown list, since the marks function is used frequently, it's better to show marks in a tab that can be viewed with a single click.
![image](https://github.com/variar/klogg/assets/20141496/9b37b5ec-0838-4088-bcf1-fb43a8f48cfa)

**Demo**
![visibility_tabbar_demo](https://github.com/variar/klogg/assets/20141496/82bd887f-538a-44f4-ac43-75774672a7bf)
