### PR TITLE
fix: app always crashes when KEY_K/KEY_J/KEY_Up/KEY_Down is pressed

### DIFF
--- a/src/ui/include/selection.h
+++ b/src/ui/include/selection.h
@@ -183,10 +183,9 @@ class Selection {
 
         LinesCount size() const
         {
-            if (startLine)
-            {
+            if ( startLine.has_value() )
                 return LinesCount{ endLine.get() - startLine->get() + 1 };
-            }
+
             return LinesCount{ 1 };
         }
     };

--- a/src/ui/include/selection.h
+++ b/src/ui/include/selection.h
@@ -183,10 +183,7 @@ class Selection {
 
         LinesCount size() const
         {
-            if ( startLine.has_value() )
-                return LinesCount{ endLine.get() - startLine->get() + 1 };
-
-            return LinesCount{ 1 };
+            return LinesCount{ endLine.get() - startLine->get() + 1 };
         }
     };
     struct SelectedPartial selectedPartial_;

--- a/src/ui/include/selection.h
+++ b/src/ui/include/selection.h
@@ -187,7 +187,7 @@ class Selection {
             {
                 return LinesCount{ endLine.get() - startLine->get() + 1 };
             }
-            return LinesCount{ 0 };
+            return LinesCount{ 1 };
         }
     };
     struct SelectedPartial selectedPartial_;

--- a/src/ui/include/selection.h
+++ b/src/ui/include/selection.h
@@ -183,7 +183,11 @@ class Selection {
 
         LinesCount size() const
         {
-            return LinesCount{ endLine.get() - startLine->get() + 1 };
+            if (startLine)
+            {
+                return LinesCount{ endLine.get() - startLine->get() + 1 };
+            }
+            return LinesCount{ 0 };
         }
     };
     struct SelectedPartial selectedPartial_;

--- a/src/ui/src/selection.cpp
+++ b/src/ui/src/selection.cpp
@@ -152,7 +152,14 @@ klogg::vector<LineNumber> Selection::getLines() const
 
 uint64_t Selection::getSelectedLinesCount() const
 {
-    return selectedRange_.size().get();
+    if ( selectedRange_.startLine.has_value() ) {
+        return selectedRange_.size().get();
+    }
+    else if ( selectedLine_.has_value() ) {
+        return 1;
+    }
+
+    return 0;
 }
 
 // The tab behaviour is a bit odd at the moment, full lines are not expanded


### PR DESCRIPTION
App always crashes when KEY_K/KEY_J/KEY_Up/KEY_Down is pressed, this is because `startLine` is empty.
![image](https://github.com/variar/klogg/assets/20141496/133ec03b-78f9-467f-ab41-f86024b185ca)
