### PR TITLE
fix: the first tab doesn't show when a new file is opened

### DIFF
--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -140,6 +140,8 @@ void TabbedCrawlerWidget::addTabBarItem( int index, const QString& fileName )
 
     myTabBar_.setTabData( index, tabData );
 
+    setCurrentIndex(index);
+
     if ( count() > 1 )
         myTabBar_.show();
 }


### PR DESCRIPTION
**Problem**
After opening a new file, the first tab doesn't show.
![first_tab_hidden](https://github.com/variar/klogg/assets/20141496/a6c8048c-a73d-497e-91b2-f1a49feee4d2)

**Fix**
![fix_first_tab_hidden](https://github.com/variar/klogg/assets/20141496/2e1fc9e6-ef6b-4de3-8fda-8614dfd5e76a)
