### PR TITLE
fix: The last line being covered in follow mode(#117)

### DIFF
--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1195,7 +1195,8 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
     // This is to cover the special case where there is less than a screenful
     // worth of data, we want to see the document from the top, rather than
     // pushing the first couple of lines above the viewport.
-    if ( followElasticHook_.isHooked() && ( logData_->getNbLine() < getNbVisibleLines() ) ) {
+    if ( followElasticHook_.isHooked()
+         && ( logData_->getNbLine() + LinesCount( 1 ) < getNbVisibleLines() ) ) {
         drawingTopOffset_ = 0;
         drawingTopPosition += ( wholeHeight - viewport()->height() ) + PullToFollowHookedHeight;
         drawingPullToFollowTopPosition


### PR DESCRIPTION
Fix the last line being covered in follow mode when filelines*charHeight is the screen height