### PR TITLE
feat: switch to 'Marks and matches' view when starting a new search

### DIFF
--- a/src/logdata/include/logfiltereddata.h
+++ b/src/logdata/include/logfiltereddata.h
@@ -134,6 +134,7 @@ class LogFilteredData : public AbstractLogData {
     Q_ENUM( VisibilityFlags );
     Q_DECLARE_FLAGS( Visibility, VisibilityFlags )
     void setVisibility( Visibility visibility );
+    Visibility visibility() const;
 
     void iterateOverLines( const std::function<void( LineNumber )>& callback ) const;
   Q_SIGNALS:

--- a/src/logdata/src/logfiltereddata.cpp
+++ b/src/logdata/src/logfiltereddata.cpp
@@ -343,6 +343,11 @@ void LogFilteredData::setVisibility( Visibility visi )
     visibility_ = visi;
 }
 
+LogFilteredData::Visibility LogFilteredData::visibility() const
+{
+    return visibility_;
+}
+
 void LogFilteredData::updateSearchResultsCache()
 {
     const auto& config = Configuration::get();

--- a/src/ui/include/filteredview.h
+++ b/src/ui/include/filteredview.h
@@ -57,6 +57,7 @@ class FilteredView : public AbstractLogView
     // What is visible in the view.
     using Visibility = LogFilteredData::Visibility;
     void setVisibility( Visibility visi );
+    Visibility visibility() const;
 
   protected:
     LogFilteredData::LineType lineType( LineNumber lineNumber ) const override;

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -1405,6 +1405,13 @@ void CrawlerWidget::replaceCurrentSearch( const QString& searchText )
 
     nbMatches_ = 0_lcount;
 
+    // Switch to "Marks and matches" view when in "Marks" view
+    using VisibilityFlags = LogFilteredData::VisibilityFlags;
+    if (!filteredView_->visibility().testFlag(VisibilityFlags::Matches))
+    {
+        visibilityBox_->setCurrentIndex( 0 );
+    }
+
     // Clear and recompute the content of the filtered window.
     logFilteredData_->clearSearch();
     filteredView_->updateData();

--- a/src/ui/src/filteredview.cpp
+++ b/src/ui/src/filteredview.cpp
@@ -62,6 +62,13 @@ void FilteredView::setVisibility( Visibility visi )
     updateData();
 }
 
+FilteredView::Visibility FilteredView::visibility() const
+{
+    assert( logFilteredData_ );
+
+    return logFilteredData_->visibility();
+}
+
 // For the filtered view, a line is always matching!
 AbstractLogData::LineType FilteredView::lineType( LineNumber lineNumber ) const
 {


### PR DESCRIPTION
Issue:
https://github.com/variar/klogg/issues/603
When in the "Marks" tab, I perform a new search, however, it doesn't switch to the "Marks and matches" tab automatically, I have to switch the tab manually. It's better to switch to the "Marks and matches" tab automatically when starting a new search.

Change:
Switch to the "Marks and matches" tab when starting a new search if the current filtered view is "Marks".
![switch-tab](https://github.com/variar/klogg/assets/20141496/4329dedb-c47a-4f75-a534-7670c09bcf58)
