### PR TITLE
fix: make predefined filters popup wider

### DIFF
--- a/src/ui/src/predefinedfilterscombobox.cpp
+++ b/src/ui/src/predefinedfilterscombobox.cpp
@@ -97,6 +97,8 @@ PredefinedFiltersComboBox::PredefinedFiltersComboBox( QWidget* parent )
     QPalette palette = this->palette();
     palette.setColor( QPalette::Base, palette.color( QPalette::Window ) );
     view()->setPalette( palette );
+
+    view()->setFixedWidth(200);
 }
 
 void PredefinedFiltersComboBox::populatePredefinedFilters()

--- a/src/ui/src/predefinedfilterscombobox.cpp
+++ b/src/ui/src/predefinedfilterscombobox.cpp
@@ -98,6 +98,7 @@ PredefinedFiltersComboBox::PredefinedFiltersComboBox( QWidget* parent )
     palette.setColor( QPalette::Base, palette.color( QPalette::Window ) );
     view()->setPalette( palette );
 
+    view()->setTextElideMode( Qt::ElideNone );
     setSizeAdjustPolicy( QComboBox::AdjustToContents );
 }
 

--- a/src/ui/src/predefinedfilterscombobox.cpp
+++ b/src/ui/src/predefinedfilterscombobox.cpp
@@ -98,7 +98,7 @@ PredefinedFiltersComboBox::PredefinedFiltersComboBox( QWidget* parent )
     palette.setColor( QPalette::Base, palette.color( QPalette::Window ) );
     view()->setPalette( palette );
 
-    view()->setFixedWidth(200);
+    view()->setFixedWidth( 200 );
 }
 
 void PredefinedFiltersComboBox::populatePredefinedFilters()

--- a/src/ui/src/predefinedfilterscombobox.cpp
+++ b/src/ui/src/predefinedfilterscombobox.cpp
@@ -98,7 +98,7 @@ PredefinedFiltersComboBox::PredefinedFiltersComboBox( QWidget* parent )
     palette.setColor( QPalette::Base, palette.color( QPalette::Window ) );
     view()->setPalette( palette );
 
-    view()->setFixedWidth( 200 );
+    setSizeAdjustPolicy( QComboBox::AdjustToContents );
 }
 
 void PredefinedFiltersComboBox::populatePredefinedFilters()


### PR DESCRIPTION
In the predefined filters drop-down list, the filters are truncated, this PR aims to make the drop-down list wider.

Before:
![247550534-455d606e-d727-4abb-b792-e919b095c40a](https://github.com/variar/klogg/assets/20141496/70dc486b-26fb-4de5-b103-5cfe9055a895)
Now:
![Snipaste_2023-06-22_17-43-10](https://github.com/variar/klogg/assets/20141496/687cd401-b090-49ec-98aa-ec900bcdd810)
