### PR TITLE
feat: support changing filtered lines visibility backward

### DIFF
--- a/src/settings/include/shortcuts.h
+++ b/src/settings/include/shortcuts.h
@@ -30,8 +30,11 @@ class QWidget;
 class QShortcut;
 
 struct ShortcutAction {
-    static constexpr auto CrawlerChangeVisibilityForward = "crawler.change_visibility_type_forward";
+    static constexpr auto CrawlerChangeVisibilityForward = "crawler.change_visibility_type";
     static constexpr auto CrawlerChangeVisibilityBackward = "crawler.change_visibility_type_backward";
+    static constexpr auto CrawlerChangeVisibilityToMarksAndMatches = "crawler.change_visibility_type_marks_and_matches";
+    static constexpr auto CrawlerChangeVisibilityToMarks = "crawler.change_visibility_type_marks";
+    static constexpr auto CrawlerChangeVisibilityToMatches = "crawler.change_visibility_type_matches";
     static constexpr auto CrawlerIncreseTopViewSize = "crawler.increase_top_view_size";
     static constexpr auto CrawlerDecreaseTopViewSize = "crawler.decrease_top_view_size";
 

--- a/src/settings/include/shortcuts.h
+++ b/src/settings/include/shortcuts.h
@@ -32,9 +32,9 @@ class QShortcut;
 struct ShortcutAction {
     static constexpr auto CrawlerChangeVisibilityForward = "crawler.change_visibility_type";
     static constexpr auto CrawlerChangeVisibilityBackward = "crawler.change_visibility_type_backward";
-    static constexpr auto CrawlerChangeVisibilityToMarksAndMatches = "crawler.change_visibility_type_marks_and_matches";
-    static constexpr auto CrawlerChangeVisibilityToMarks = "crawler.change_visibility_type_marks";
-    static constexpr auto CrawlerChangeVisibilityToMatches = "crawler.change_visibility_type_matches";
+    static constexpr auto CrawlerChangeVisibilityToMarksAndMatches = "crawler.change_visibility_to_marks_and_matches";
+    static constexpr auto CrawlerChangeVisibilityToMarks = "crawler.change_visibility_to_marks";
+    static constexpr auto CrawlerChangeVisibilityToMatches = "crawler.change_visibility_to_matches";
     static constexpr auto CrawlerIncreseTopViewSize = "crawler.increase_top_view_size";
     static constexpr auto CrawlerDecreaseTopViewSize = "crawler.decrease_top_view_size";
 

--- a/src/settings/include/shortcuts.h
+++ b/src/settings/include/shortcuts.h
@@ -30,7 +30,8 @@ class QWidget;
 class QShortcut;
 
 struct ShortcutAction {
-    static constexpr auto CrawlerChangeVisibility = "crawler.change_visibility_type";
+    static constexpr auto CrawlerChangeVisibilityForward = "crawler.change_visibility_type_forward";
+    static constexpr auto CrawlerChangeVisibilityBackward = "crawler.change_visibility_type_backward";
     static constexpr auto CrawlerIncreseTopViewSize = "crawler.increase_top_view_size";
     static constexpr auto CrawlerDecreaseTopViewSize = "crawler.decrease_top_view_size";
 

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -77,6 +77,12 @@ const std::map<std::string, QStringList>& ShortcutAction::defaultShortcuts()
         shortcuts.emplace( CrawlerChangeVisibilityBackward, QStringList()
                                                         << "Shift+`"
                                                         << "Shift+V" );
+        shortcuts.emplace( CrawlerChangeVisibilityToMarksAndMatches,
+                          QStringList() << QKeySequence( Qt::Key_1 ).toString() );
+        shortcuts.emplace( CrawlerChangeVisibilityToMarks,
+                          QStringList() << QKeySequence( Qt::Key_2 ).toString() );
+        shortcuts.emplace( CrawlerChangeVisibilityToMatches,
+                          QStringList() << QKeySequence( Qt::Key_3 ).toString() );
         shortcuts.emplace( CrawlerIncreseTopViewSize,
                            QStringList() << QKeySequence( Qt::Key_Plus ).toString() );
         shortcuts.emplace( CrawlerDecreaseTopViewSize,
@@ -208,6 +214,12 @@ QString ShortcutAction::actionName( const std::string& action )
                            QApplication::tr( "Change filtered lines visibility forward" ) );
         shortcuts.emplace( CrawlerChangeVisibilityBackward,
                            QApplication::tr( "Change filtered lines visibility backward" ) );
+        shortcuts.emplace( CrawlerChangeVisibilityToMarksAndMatches,
+                          QApplication::tr( "Change filtered lines visibility to marks and matches" ) );
+        shortcuts.emplace( CrawlerChangeVisibilityToMarks,
+                          QApplication::tr( "Change filtered lines visibility to marks" ) );
+        shortcuts.emplace( CrawlerChangeVisibilityToMatches,
+                          QApplication::tr( "Change filtered lines visibility to matches" ) );
         shortcuts.emplace( CrawlerIncreseTopViewSize, QApplication::tr( "Increase main view" ) );
         shortcuts.emplace( CrawlerDecreaseTopViewSize, QApplication::tr( "Decrease main view" ) );
 

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -78,11 +78,11 @@ const std::map<std::string, QStringList>& ShortcutAction::defaultShortcuts()
                                                         << "Shift+`"
                                                         << "Shift+V" );
         shortcuts.emplace( CrawlerChangeVisibilityToMarksAndMatches,
-                          QStringList() << QKeySequence( Qt::Key_1 ).toString() );
+                           QStringList() << QKeySequence( Qt::Key_1 ).toString() );
         shortcuts.emplace( CrawlerChangeVisibilityToMarks,
-                          QStringList() << QKeySequence( Qt::Key_2 ).toString() );
+                           QStringList() << QKeySequence( Qt::Key_2 ).toString() );
         shortcuts.emplace( CrawlerChangeVisibilityToMatches,
-                          QStringList() << QKeySequence( Qt::Key_3 ).toString() );
+                           QStringList() << QKeySequence( Qt::Key_3 ).toString() );
         shortcuts.emplace( CrawlerIncreseTopViewSize,
                            QStringList() << QKeySequence( Qt::Key_Plus ).toString() );
         shortcuts.emplace( CrawlerDecreaseTopViewSize,

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -72,11 +72,9 @@ const std::map<std::string, QStringList>& ShortcutAction::defaultShortcuts()
         shortcuts.emplace( MainWindowSelectOpenFile, QStringList() << "Ctrl+Shift+O" );
 
         shortcuts.emplace( CrawlerChangeVisibilityForward, QStringList()
-                                                        << QKeySequence( Qt::Key_QuoteLeft ).toString()
-                                                        << QKeySequence( Qt::Key_V ).toString() );
+                                                               << QKeySequence( Qt::Key_V ).toString() );
         shortcuts.emplace( CrawlerChangeVisibilityBackward, QStringList()
-                                                        << "Shift+`"
-                                                        << "Shift+V" );
+                                                               << "Shift+V" );
         shortcuts.emplace( CrawlerChangeVisibilityToMarksAndMatches,
                            QStringList() << QKeySequence( Qt::Key_1 ).toString() );
         shortcuts.emplace( CrawlerChangeVisibilityToMarks,

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -71,8 +71,12 @@ const std::map<std::string, QStringList>& ShortcutAction::defaultShortcuts()
         shortcuts.emplace( MainWindowScratchpad, QStringList() );
         shortcuts.emplace( MainWindowSelectOpenFile, QStringList() << "Ctrl+Shift+O" );
 
-        shortcuts.emplace( CrawlerChangeVisibility, QStringList()
+        shortcuts.emplace( CrawlerChangeVisibilityForward, QStringList()
+                                                        << QKeySequence( Qt::Key_QuoteLeft ).toString()
                                                         << QKeySequence( Qt::Key_V ).toString() );
+        shortcuts.emplace( CrawlerChangeVisibilityBackward, QStringList()
+                                                        << "Shift+`"
+                                                        << "Shift+V" );
         shortcuts.emplace( CrawlerIncreseTopViewSize,
                            QStringList() << QKeySequence( Qt::Key_Plus ).toString() );
         shortcuts.emplace( CrawlerDecreaseTopViewSize,
@@ -200,8 +204,10 @@ QString ShortcutAction::actionName( const std::string& action )
         shortcuts.emplace( MainWindowScratchpad, QApplication::tr( "Open scratchpad" ) );
         shortcuts.emplace( MainWindowSelectOpenFile, QApplication::tr( "Switch to file" ) );
 
-        shortcuts.emplace( CrawlerChangeVisibility,
-                           QApplication::tr( "Change filtered lines visibility" ) );
+        shortcuts.emplace( CrawlerChangeVisibilityForward,
+                           QApplication::tr( "Change filtered lines visibility forward" ) );
+        shortcuts.emplace( CrawlerChangeVisibilityBackward,
+                           QApplication::tr( "Change filtered lines visibility backward" ) );
         shortcuts.emplace( CrawlerIncreseTopViewSize, QApplication::tr( "Increase main view" ) );
         shortcuts.emplace( CrawlerDecreaseTopViewSize, QApplication::tr( "Decrease main view" ) );
 

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -288,7 +288,7 @@ QString ShortcutAction::actionName( const std::string& action )
 
     const auto name = actionNames.find( action );
 
-    return name != actionNames.end() ? name->second : "";
+    return name != actionNames.end() ? name->second : QString::fromStdString( action );
 }
 
 void ShortcutAction::registerShortcut( const ConfiguredShortcuts& configuredShortcuts,

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -288,7 +288,7 @@ QString ShortcutAction::actionName( const std::string& action )
 
     const auto name = actionNames.find( action );
 
-    return name != actionNames.end() ? name->second : QString::fromStdString( action );
+    return name != actionNames.end() ? name->second : "";
 }
 
 void ShortcutAction::registerShortcut( const ConfiguredShortcuts& configuredShortcuts,

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -1326,9 +1326,19 @@ void CrawlerWidget::registerShortcuts()
 
     ShortcutAction::registerShortcut(
         configuredShortcuts, shortcuts_, this, Qt::WidgetWithChildrenShortcut,
-        ShortcutAction::CrawlerChangeVisibility, [ this ]() {
+        ShortcutAction::CrawlerChangeVisibilityForward, [ this ]() {
             visibilityBox_->setCurrentIndex( ( visibilityBox_->currentIndex() + 1 )
                                              % visibilityBox_->count() );
+        } );
+
+    ShortcutAction::registerShortcut(
+        configuredShortcuts, shortcuts_, this, Qt::WidgetWithChildrenShortcut,
+        ShortcutAction::CrawlerChangeVisibilityBackward, [ this ]() {
+            int nextIndex = visibilityBox_->currentIndex() - 1;
+            if ( nextIndex < 0 ) {
+                nextIndex = visibilityBox_->count() - 1;
+            }
+            visibilityBox_->setCurrentIndex( nextIndex );
         } );
 
     ShortcutAction::registerShortcut(

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -1343,6 +1343,30 @@ void CrawlerWidget::registerShortcuts()
 
     ShortcutAction::registerShortcut(
         configuredShortcuts, shortcuts_, this, Qt::WidgetWithChildrenShortcut,
+        ShortcutAction::CrawlerChangeVisibilityToMarksAndMatches, [ this ]() {
+            if ( visibilityBox_->count() > 0 ) {
+                visibilityBox_->setCurrentIndex( 0 );
+            }
+        } );
+
+    ShortcutAction::registerShortcut(
+        configuredShortcuts, shortcuts_, this, Qt::WidgetWithChildrenShortcut,
+        ShortcutAction::CrawlerChangeVisibilityToMarks, [ this ]() {
+            if ( visibilityBox_->count() > 1 ) {
+                visibilityBox_->setCurrentIndex( 1 );
+            }
+        } );
+
+    ShortcutAction::registerShortcut(
+        configuredShortcuts, shortcuts_, this, Qt::WidgetWithChildrenShortcut,
+        ShortcutAction::CrawlerChangeVisibilityToMatches, [ this ]() {
+            if ( visibilityBox_->count() > 2 ) {
+                visibilityBox_->setCurrentIndex( 2 );
+            }
+        } );
+
+    ShortcutAction::registerShortcut(
+        configuredShortcuts, shortcuts_, this, Qt::WidgetWithChildrenShortcut,
         ShortcutAction::CrawlerIncreseTopViewSize, [ this ]() { changeTopViewSize( 1 ); } );
 
     ShortcutAction::registerShortcut(

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -665,15 +665,10 @@ void OptionsDialog::buildShortcutsTable( bool useDefaultsOnly )
     }
 
     for ( const auto& [ action, keys ] : shortcuts ) {
-        auto shortcutActionName = ShortcutAction::actionName( action );
-        if ( shortcutActionName.isEmpty() ) {
-            continue;
-        }
-
         auto currentRow = shortcutsTable->rowCount();
         shortcutsTable->insertRow( currentRow );
 
-        auto keyItem = new QTableWidgetItem( shortcutActionName );
+        auto keyItem = new QTableWidgetItem( ShortcutAction::actionName( action ) );
         keyItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
         keyItem->setData( Qt::UserRole, QString::fromStdString( action ) );
         shortcutsTable->setItem( currentRow, 0, keyItem );

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -665,10 +665,15 @@ void OptionsDialog::buildShortcutsTable( bool useDefaultsOnly )
     }
 
     for ( const auto& [ action, keys ] : shortcuts ) {
+        auto shortcutActionName = ShortcutAction::actionName( action );
+        if ( shortcutActionName.isEmpty() ) {
+            continue;
+        }
+
         auto currentRow = shortcutsTable->rowCount();
         shortcutsTable->insertRow( currentRow );
 
-        auto keyItem = new QTableWidgetItem( ShortcutAction::actionName( action ) );
+        auto keyItem = new QTableWidgetItem( shortcutActionName );
         keyItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
         keyItem->setData( Qt::UserRole, QString::fromStdString( action ) );
         shortcutsTable->setItem( currentRow, 0, keyItem );


### PR DESCRIPTION
**Problem**
Currently, we can change filtered lines' visibility with the shortcut "Key_V". However, the shortcut can only change the visibility forward, so we have to click Key_V twice to return to the current view.

**Change**
With the changes in this PR, we can change the filtered lines' visibility forward and backward.
- Forward: V
- Backward: Shift+V

_Shortcut preferences:_

![image](https://github.com/variar/klogg/assets/20141496/8ca278a5-8ea4-4d14-8538-0a6d9bcca55a)


