### PR TITLE
fix: fix some UI issues in Preference->Shortcuts table

### DIFF
--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -686,8 +686,11 @@ void OptionsDialog::buildShortcutsTable( bool useDefaultsOnly )
                  &OptionsDialog::checkShortcutsOnDuplicate );
     }
 
-    shortcutsTable->horizontalHeader()->setSectionResizeMode( QHeaderView::Stretch );
     shortcutsTable->verticalHeader()->setSectionResizeMode( QHeaderView::Stretch );
+    shortcutsTable->horizontalHeader()->setSectionResizeMode( QHeaderView::Stretch );
+    shortcutsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Interactive);
+    shortcutsTable->horizontalHeader()->setMinimumSectionSize(150);
+    shortcutsTable->resizeColumnToContents(0);
     shortcutsTable->setHorizontalHeaderItem( 0, new QTableWidgetItem( tr( "Action" ) ) );
     shortcutsTable->setHorizontalHeaderItem( 1, new QTableWidgetItem( tr( "Primary shortcut" ) ) );
     shortcutsTable->setHorizontalHeaderItem( 2,

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -605,6 +605,7 @@ KeySequencePresenter::KeySequencePresenter( const QString& keySequence )
 
     auto editButton = new QPushButton();
     editButton->setText( "..." );
+    editButton->setFixedWidth( 50 );
 
     auto layout = new QHBoxLayout();
 
@@ -686,11 +687,10 @@ void OptionsDialog::buildShortcutsTable( bool useDefaultsOnly )
                  &OptionsDialog::checkShortcutsOnDuplicate );
     }
 
-    shortcutsTable->verticalHeader()->setSectionResizeMode( QHeaderView::Stretch );
     shortcutsTable->horizontalHeader()->setSectionResizeMode( QHeaderView::Stretch );
-    shortcutsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Interactive);
-    shortcutsTable->horizontalHeader()->setMinimumSectionSize(150);
-    shortcutsTable->resizeColumnToContents(0);
+    shortcutsTable->horizontalHeader()->setSectionResizeMode( 0, QHeaderView::Interactive );
+    shortcutsTable->horizontalHeader()->setMinimumSectionSize( 150 );
+    shortcutsTable->resizeColumnToContents( 0 );
     shortcutsTable->setHorizontalHeaderItem( 0, new QTableWidgetItem( tr( "Action" ) ) );
     shortcutsTable->setHorizontalHeaderItem( 1, new QTableWidgetItem( tr( "Primary shortcut" ) ) );
     shortcutsTable->setHorizontalHeaderItem( 2,


### PR DESCRIPTION
**Problem 1**
Some action descriptions are not shown completely.
![Snipaste_2023-06-23_13-58-44](https://github.com/variar/klogg/assets/20141496/e7fd6237-f61f-4396-be96-ca14a1a3fa03)

**Problem 2**
The row height is not enough to show the text and button completely.
<img width="614" alt="Snipaste_2023-06-23_14-59-08" src="https://github.com/variar/klogg/assets/20141496/62c770c4-a5eb-4449-8672-051a8db1604d">

**Fix**
1. Resize the action column to contents.
2. Don't stretch rows

Windows:
![image](https://github.com/variar/klogg/assets/20141496/a70ec97d-7b10-4326-8df8-728aecf45d2f)
Mac:
<img width="704" alt="Snipaste_2023-06-23_15-01-28" src="https://github.com/variar/klogg/assets/20141496/adf1223d-bf02-47ee-a0bb-b6eb84cb7170">
