### PR TITLE
fix: predefined filters table row height is too small

### DIFF
--- a/src/ui/src/predefinedfiltersdialog.cpp
+++ b/src/ui/src/predefinedfiltersdialog.cpp
@@ -223,6 +223,8 @@ void PredefinedFiltersDialog::addFilterRow( const QString& newFilter )
     filtersTableWidget->scrollToItem( filtersTableWidget->item( newRow, 0 ) );
     filtersTableWidget->setCurrentCell( newRow, 0 );
     filtersTableWidget->editItem( filtersTableWidget->item( newRow, 0 ) );
+
+    filtersTableWidget->resizeRowToContents( newRow );
 }
 
 void PredefinedFiltersDialog::removeFilter()


### PR DESCRIPTION
**Problem**
The regex checkbox doesn't display completely.
![image](https://github.com/variar/klogg/assets/20141496/3cd68a79-1b23-41e7-9ad3-f52685ad3a05)

**Fix**
Resize new row to contents.
![image](https://github.com/variar/klogg/assets/20141496/2e7880d8-e412-46be-b147-2a3f18d17b7d)
