### PR TITLE
fix: Scratchpad Format Json does not handle Json arrays(#490)

### DIFF
--- a/src/ui/src/scratchpad.cpp
+++ b/src/ui/src/scratchpad.cpp
@@ -320,7 +320,7 @@ void ScratchPad::hexToDec()
 void ScratchPad::formatJson()
 {
     transformTextInPlace( []( QString text ) {
-        const auto start = text.indexOf( '{' );
+        const auto start = std::min(text.indexOf( '{' ), text.indexOf('['));
 
         QJsonParseError parseError;
         auto json = QJsonDocument::fromJson( text.mid( start ).toUtf8(), &parseError );


### PR DESCRIPTION
Related issues #490