### PR TITLE
fix: crash when closing search results tab and scrolling till the end of view (#614)

### DIFF
--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -1246,6 +1246,7 @@ void CrawlerWidget::setup()
 
         filteredViewsData_.erase( tmp );
         tabbedFilteredView_->removeTab( index );
+        tmp->deleteLater();
     } );
 
     connect( logMainView_, &LogMainView::saveDefaultSplitterSizes, this,


### PR DESCRIPTION
related to #614