### PR TITLE
fix: can't scroll horizontally when moving mouse to select more texts…

### DIFF
--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -740,14 +740,15 @@ void AbstractLogView::mouseMoveEvent( QMouseEvent* mouseEvent )
                 update();
             }
             selectionCurrentEndPos_ = thisEndPos;
-
-            // Do we need to scroll while extending the selection?
-            QRect visible = viewport()->rect();
-            if ( visible.contains( mouseEvent->pos() ) )
-                autoScrollTimer_.stop();
-            else if ( !autoScrollTimer_.isActive() )
-                autoScrollTimer_.start( 100, this );
         }
+
+        // Do we need to scroll while extending the selection?
+        QRect visible = viewport()->rect();
+        visible.setLeft( leftMarginPx_ );
+        if ( visible.contains( mouseEvent->pos() ) )
+            autoScrollTimer_.stop();
+        else if ( !autoScrollTimer_.isActive() )
+            autoScrollTimer_.start( 100, this );
     }
     else {
         considerMouseHovering( mouseEvent->pos().x(), mouseEvent->pos().y() );
@@ -791,6 +792,7 @@ void AbstractLogView::timerEvent( QTimerEvent* timerEvent )
 {
     if ( timerEvent->timerId() == autoScrollTimer_.timerId() ) {
         QRect visible = viewport()->rect();
+        visible.setLeft( leftMarginPx_ );
         const QPoint globalPos = QCursor::pos();
         const QPoint pos = viewport()->mapFromGlobal( globalPos );
         QMouseEvent ev( QEvent::MouseMove, pos, globalPos, Qt::LeftButton, Qt::LeftButton,


### PR DESCRIPTION
… in a line

**Problem**
When moving the mouse left to select more texts, it doesn't scroll left automatically.
![hscroll_issue](https://github.com/variar/klogg/assets/20141496/44eac948-8d73-42a2-950c-a69f6e657945)

**Fix**
![fix_hscroll_issue](https://github.com/variar/klogg/assets/20141496/dcb74270-fe2d-417a-a5f6-14d42bef9143)
