### PR TITLE
fix: view log crash if Qt version < 5.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ website/public
 .idea/
 cmake-build-debug/
 cmake-build-release/
+cmake-build-relwithdebinfo/
 
 #website
 website/hugo


### PR DESCRIPTION
> Note: Until 5.15.1, the behavior was undefined when start < 0, length < 0, or start + length > [size](https://doc.qt.io/qt-5/qstringview.html#size)(). Since 5.15.2, the behavior is compatible with [QString::mid](https://doc.qt.io/qt-5/qstring.html#mid)().

Link to original article：[QStringView::mid](https://doc.qt.io/qt-5/qstringview.html#mid-1)

The second parameter of `QStringView::mid` has undefined behavior before `Qt 5.15.1` and behaves normally in Windows, but there is out-of-bounds access in Linux

Related issues #622 