### PR TITLE
feat: show unmark in the right-click memu for the marked line

### DIFF
--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -611,6 +611,18 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
             setSelectionEndAction_->setEnabled( false );
         }
 
+        bool hasUnmarkedLines = false;
+        auto lines = selection_.getLines();
+        for ( auto i = 0u; i < lines.size(); ++i ) {
+            using LineTypeFlags = AbstractLogData::LineTypeFlags;
+            const auto currentLineType = lineType( lines[ i ] );
+            if ( !currentLineType.testFlag( LineTypeFlags::Mark ) ) {
+                hasUnmarkedLines = true;
+                break;
+            }
+        }
+        markAction_->setText( hasUnmarkedLines ? tr( "&Mark" ) : tr( "Unmark" ) );
+
         if ( selection_.isPortion() ) {
             findNextAction_->setEnabled( true );
             findPreviousAction_->setEnabled( true );


### PR DESCRIPTION
Sometimes I accidentally remove a marked line from the right-click menu. This PR makes a change to show "Unmark" in the right-client menu for the marked line.

Show "Unmark" for the marked line:
![image](https://github.com/variar/klogg/assets/20141496/a58b8ce6-99bf-4cf4-b659-bccaeff1e295)

Still show "Mark" when there is an unmarked line selected:
![image](https://github.com/variar/klogg/assets/20141496/d426f178-3eea-4d61-9eb7-de5f7a71a98e)

