### PR TITLE
fix: predefined filters table row height is too small on Windows

### DIFF
--- a/src/ui/src/predefinedfiltersdialog.cpp
+++ b/src/ui/src/predefinedfiltersdialog.cpp
@@ -169,7 +169,10 @@ void PredefinedFiltersDialog::populateFiltersTable(
         filterIndex++;
     }
 
+    filtersTableWidget->horizontalHeader()->setSectionResizeMode( 0, QHeaderView::ResizeToContents );
     filtersTableWidget->horizontalHeader()->setSectionResizeMode( 1, QHeaderView::Stretch );
+    filtersTableWidget->verticalHeader()->setSectionResizeMode( QHeaderView::ResizeToContents );
+    filtersTableWidget->setWordWrap( false );
 
     updateButtons();
 }


### PR DESCRIPTION
**Problem**
The regex checkbox doesn't display completely on Windows. I had a [fix ](https://github.com/variar/klogg/pull/611) for the newly added row, but it can't cover the existing rows.
![image](https://github.com/variar/klogg/assets/20141496/622c96da-c9f2-4daf-a521-e4004952476c)

**Fix**
1. Resize rows to contents
2. Resize the first column to contents
![image](https://github.com/variar/klogg/assets/20141496/cabd8adf-a948-4598-8a85-046e363c61ea)
