### PR TITLE
fix: crash on exit when the first empty filtered view tab is closed

### DIFF
--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -181,6 +181,9 @@ class CrawlerWidget : public QSplitter,
     // available) has changed
     void dataStatusChanged( DataStatus status );
 
+    // Sent up when the current filtered view has been changed
+    void filteredViewChanged();
+
   private Q_SLOTS:
     // Instructs the widget to start a search using the current search line.
     void startNewSearch();

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -164,6 +164,9 @@ class MainWindow : public QMainWindow {
     void handleSearchRefreshChanged( bool isRefreshing );
     void handleMatchCaseChanged( bool matchCase );
 
+    // Update quick find searchable
+    void handleFilteredViewChanged();
+
     // Close the tab with the passed index
     void closeTab( int index, ActionInitiator initiator );
     // Setup the tab with current index for view

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -1236,6 +1236,7 @@ void CrawlerWidget::setup()
         logFilteredData_->interruptSearch();
         if ( index >= 0 ) {
             filteredView_ = qobject_cast<FilteredView*>( tabbedFilteredView_->widget( index ) );
+            Q_EMIT filteredViewChanged();
             logFilteredData_ = filteredViewsData_.at( filteredView_ );
             logMainView_->useNewFiltering( logFilteredData_.get() );
             changeFilteredViewVisibility( visibilityBox_->currentIndex() );
@@ -1250,7 +1251,7 @@ void CrawlerWidget::setup()
         }
 
         tabbedFilteredView_->removeTab( index );
-        filteredViewsData_.erase( qobject_cast<FilteredView*>( tmp ) );
+        filteredViewsData_.erase( tmp );
         tmp->deleteLater();
     } );
 

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1431,8 +1431,7 @@ void MainWindow::handleMatchCaseChanged( bool matchCase )
 void MainWindow::handleFilteredViewChanged()
 {
     int currentIndex = mainTabWidget_.currentIndex();
-    if ( currentIndex >= 0 )
-    {
+    if ( currentIndex >= 0 ) {
         auto* crawler_widget = static_cast<CrawlerWidget*>( mainTabWidget_.widget( currentIndex ) );
         quickFindMux_.registerSelector( crawler_widget );
     }

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -185,6 +185,9 @@ MainWindow::MainWindow( WindowSession session )
     signalMux_.connect( SIGNAL( matchCaseChanged( bool ) ), this,
                         SLOT( handleMatchCaseChanged( bool ) ) );
 
+    signalMux_.connect( SIGNAL( filteredViewChanged() ), this,
+                       SLOT( handleFilteredViewChanged() ) );
+
     // Configure the main tabbed widget
     mainTabWidget_.setDocumentMode( true );
     mainTabWidget_.setMovable( true );
@@ -1423,6 +1426,16 @@ void MainWindow::handleMatchCaseChanged( bool matchCase )
     auto& config = Configuration::get();
     config.setSearchIgnoreCaseDefault( !matchCase );
     config.save();
+}
+
+void MainWindow::handleFilteredViewChanged()
+{
+    int currentIndex = mainTabWidget_.currentIndex();
+    if ( currentIndex >= 0 )
+    {
+        auto* crawler_widget = static_cast<CrawlerWidget*>( mainTabWidget_.widget( currentIndex ) );
+        quickFindMux_.registerSelector( crawler_widget );
+    }
 }
 
 void MainWindow::closeTab( int index, ActionInitiator initiator )


### PR DESCRIPTION
Fix an extra crash issue in https://github.com/variar/klogg/issues/628

This PR not only fixes the crash issue, it also covers the quick search issue in the filtered view tab. Without this change, the "Find next" and "Finx previous" don't work in the filtered view tab.
![image](https://github.com/variar/klogg/assets/20141496/6930964a-fc90-47b0-950c-ead54db99cc9)
