### PR TITLE
fix: some ANSI colors cannot be hidden

### DIFF
--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -77,7 +77,7 @@
 #include "savedsearches.h"
 #include "shortcuts.h"
 
-static constexpr char AnsiColorSequenceRegex[] = "\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[mK]";
+static constexpr char AnsiColorSequenceRegex[] = "\\x1B\\[([0-9]{1,2}((;|:)[0-9]{1,3})*)?[mK]";
 
 // Palette for error signaling (yellow background)
 const QPalette CrawlerWidget::ErrorPalette( Qt::darkYellow );


### PR DESCRIPTION
- Fix 3/4-bit ANSI can't hide multi-color
- Support hiding 8-bit ANSI colors
- Support hiding 24-bit ANSI colors

Reference Documents：https://en.wikipedia.org/wiki/ANSI_escape_code

## Test cases
![image](https://github.com/variar/klogg/assets/31587297/13068cf3-65bc-4e10-9541-f5e15b1d2d32)

## Before
![image](https://github.com/variar/klogg/assets/31587297/1d393a8d-540a-42f4-9312-d460a6f6f9aa)

## After
![image](https://github.com/variar/klogg/assets/31587297/751b06ae-31fb-4400-a7a7-56d07db15cd3)

