### PR TITLE
fix: ANSI color parameter support without separator

### DIFF
--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -77,7 +77,7 @@
 #include "savedsearches.h"
 #include "shortcuts.h"
 
-static constexpr char AnsiColorSequenceRegex[] = "\\x1B\\[([0-9]{1,2}((;|:)[0-9]{1,3})*)?[mK]";
+static constexpr char AnsiColorSequenceRegex[] = "\\x1B\\[([0-9]{1,4}((;|:)[0-9]{1,3})*)?[mK]";
 
 // Palette for error signaling (yellow background)
 const QPalette CrawlerWidget::ErrorPalette( Qt::darkYellow );


### PR DESCRIPTION
Sorry，I forgot a special case.
## case
Because 0 is a special number, parameters starting with 0 are allowed to omit the separator from subsequent parameters.
The foreground parameter contains 30-37, 90-97 and the background color parameter contains 40-47, 100-107, so there exists a case `\033[0101m RED TEXT\033[0m`
![image](https://github.com/variar/klogg/assets/31587297/803ed118-59d4-4275-bcde-57014c529329)
