### PR TITLE
feat: Add time zone conversion to time in scratchpad

### DIFF
--- a/src/ui/include/scratchpad.h
+++ b/src/ui/include/scratchpad.h
@@ -29,6 +29,10 @@ class QPlainTextEdit;
 class QStatusBar;
 class QLineEdit;
 
+namespace klogg {
+class DateTimeBox;
+} // namespace klogg
+
 class ScratchPad : public QWidget {
     Q_OBJECT
   public:
@@ -48,7 +52,6 @@ class ScratchPad : public QWidget {
   private Q_SLOTS:
     void crc32Hex();
     void crc32Dec();
-    void unixTime();
     void fileTime();
     void decToHex();
     void hexToDec();
@@ -75,10 +78,10 @@ class ScratchPad : public QWidget {
 
     QLineEdit* crc32HexBox_;
     QLineEdit* crc32DecBox_;
-    QLineEdit* unixTimeBox_;
     QLineEdit* fileTimeBox_;
     QLineEdit* decToHexBox_;
     QLineEdit* hexToDecBox_;
+    klogg::DateTimeBox* timeBox_;
 };
 
 #endif // SCRATCHPAD_H

--- a/src/ui/src/scratchpad.cpp
+++ b/src/ui/src/scratchpad.cpp
@@ -20,11 +20,13 @@
 #include "scratchpad.h"
 
 #include <memory>
+#include <optional>
 
 #include <QAction>
 #include <QApplication>
 #include <QByteArray>
 #include <QClipboard>
+#include <QComboBox>
 #include <QDateTime>
 #include <QDomDocument>
 #include <QFormLayout>
@@ -32,11 +34,31 @@
 #include <QLineEdit>
 #include <QPlainTextEdit>
 #include <QStatusBar>
+#include <QTimeZone>
 #include <QToolBar>
 #include <QUrl>
 #include <QVBoxLayout>
 
 #include "crc32.h"
+
+namespace klogg {
+
+class DateTimeBox : public QFormLayout {
+  public:
+    DateTimeBox();
+    ~DateTimeBox() = default;
+
+    QString displayTime( const QString& text );
+
+  private:
+    QString displayTime();
+
+  private:
+    std::optional<qint64> timestamp_;
+    QLineEdit* timeLine_;
+    QComboBox* tzComboBox_;
+};
+} // namespace klogg
 
 namespace {
 
@@ -123,10 +145,14 @@ ScratchPad::ScratchPad( QWidget* parent )
 
     addBoxToLayout( "CRC32 hex", &crc32HexBox_, &ScratchPad::crc32Hex );
     addBoxToLayout( "CRC32 dec", &crc32DecBox_, &ScratchPad::crc32Dec );
-    addBoxToLayout( "Unix time", &unixTimeBox_, &ScratchPad::unixTime );
     addBoxToLayout( "File time", &fileTimeBox_, &ScratchPad::fileTime );
     addBoxToLayout( "Dec->Hex", &decToHexBox_, &ScratchPad::decToHex );
     addBoxToLayout( "Hex->Dec", &hexToDecBox_, &ScratchPad::hexToDec );
+    timeBox_ = new klogg::DateTimeBox();
+    transLayout->addRow( timeBox_ );
+    connect( this, &ScratchPad::updateTransformation, [ this ]() {
+        transformText( [ this ]( QString text ) { return timeBox_->displayTime( text ); } );
+    } );
 
     auto hLayout = std::make_unique<QHBoxLayout>();
     hLayout->addWidget( textEdit.get(), 3 );
@@ -255,23 +281,6 @@ void ScratchPad::crc32Dec()
     } ) );
 }
 
-void ScratchPad::unixTime()
-{
-    unixTimeBox_->setText( transformText( []( QString text ) {
-        bool isOk = false;
-        const auto unixTime = text.toUtf8().toLongLong( &isOk );
-        if ( isOk ) {
-            QDateTime dateTime;
-            dateTime.setTimeSpec( Qt::UTC );
-            dateTime.setSecsSinceEpoch( unixTime );
-            return dateTime.toString( Qt::ISODate );
-        }
-        else {
-            return QString{};
-        }
-    } ) );
-}
-
 void ScratchPad::fileTime()
 {
     fileTimeBox_->setText( transformText( []( QString text ) {
@@ -320,7 +329,7 @@ void ScratchPad::hexToDec()
 void ScratchPad::formatJson()
 {
     transformTextInPlace( []( QString text ) {
-        const auto start = std::min(text.indexOf( '{' ), text.indexOf('['));
+        const auto start = std::min( text.indexOf( '{' ), text.indexOf( '[' ) );
 
         QJsonParseError parseError;
         auto json = QJsonDocument::fromJson( text.mid( start ).toUtf8(), &parseError );
@@ -343,4 +352,51 @@ void ScratchPad::formatXml()
 
         return xml.toString( 2 );
     } );
+}
+
+klogg::DateTimeBox::DateTimeBox()
+    : QFormLayout()
+    , timestamp_()
+    , timeLine_( new QLineEdit() )
+    , tzComboBox_( new QComboBox() )
+{
+    addRow( tr( "Time" ), timeLine_ );
+    timeLine_->setReadOnly( true );
+
+    addRow( tr( "TimeZone" ), tzComboBox_ );
+    connect( tzComboBox_, &QComboBox::currentTextChanged, [ this ] { displayTime(); } );
+    auto ids = QTimeZone::availableTimeZoneIds();
+    std::for_each( ids.begin(), ids.end(), [ & ]( const auto& item ) {
+        if ( item.contains( "UTC" ) ) {
+            tzComboBox_->addItem( item );
+        }
+    } );
+}
+
+QString klogg::DateTimeBox::displayTime( const QString& text )
+{
+    bool isOk = false;
+    const auto unixTime = text.toUtf8().toLongLong( &isOk );
+    if ( !isOk ) {
+        timestamp_.reset();
+        timeLine_->setText( QString{} );
+        return QString{};
+    }
+    timestamp_ = unixTime;
+    return displayTime();
+}
+
+QString klogg::DateTimeBox::displayTime()
+{
+    if ( !timestamp_ ) {
+        return QString{};
+    }
+
+    // Convert to a date string for the selected time zone
+    auto tz = QTimeZone( tzComboBox_->currentData( Qt::DisplayRole ).toByteArray() );
+    auto dateTime = QDateTime::fromSecsSinceEpoch( timestamp_.value() ).toTimeZone( tz );
+    timeLine_->setText( dateTime.toString( Qt::ISODate ) );
+    timeLine_->setCursorPosition( 0 );
+
+    return timeLine_->text();
 }


### PR DESCRIPTION
The timestamps in the logs belong to different time zones, so add a conversion function
![image](https://github.com/variar/klogg/assets/31587297/a0f70175-8c56-4569-9379-b3ca0fc0d399)
