### PR TITLE
fix selected single line appearance

### DIFF
--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -2611,13 +2611,11 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
         if ( ( selection_.isLineSelected( lineNumber ) && selection_.isSingleLine() )
              || selection_.getPortionForLine( lineNumber ).isValid() ) {
             auto selectionPen = QPen( palette.color( QPalette::Highlight ) );
-            selectionPen.setWidth( 3 );
+            selectionPen.setWidth( 1 );
             painter->setPen( selectionPen );
             painter->drawLine( xPos - ContentMarginWidth + 1, yPos, viewport()->width(), yPos );
-            selectionPen.setWidth( 5 );
-            painter->setPen( selectionPen );
-            painter->drawLine( xPos - ContentMarginWidth + 2, yPos + finalLineHeight,
-                               viewport()->width(), yPos + finalLineHeight );
+            painter->drawLine( xPos - ContentMarginWidth + 1, yPos + finalLineHeight - 1,
+                               viewport()->width(), yPos + finalLineHeight - 1 );
         }
 
         // Then draw the bullet


### PR DESCRIPTION
The previous logic added a pen stroke at the top 3 pixels wide, and 5 pixels at the bottom. Probably because the lower pen stroke is misaligned (too far down) and needs a larger stroke width to compensate for this misalignment, which causes part of that stroke (the lower part) to be cut of by the next line (but not if the selection is on the last line).

This causes different effects both at lines selected in the middle of the log as well as the end of the log (last line) in different ways.

It also re-added pen several times after changing the width of the pen, which is simply unnecessary (and may have added to this effect of increasing color intensity in the original version)

The fix simple removes unnecessary lines of code as well as adjusting the position of the lower stroke and removing the previous attempt to compensate for it with stroke width.

Last line (before fix):
![1-b](https://github.com/variar/klogg/assets/431260/6cd14080-19b4-4897-acdb-0de341aac590)

Line in the middle of document (before fix):
![2-b](https://github.com/variar/klogg/assets/431260/818825dc-6ff6-47eb-a03f-b2a0c2deffb7)

Last line (after fix):
![3-b](https://github.com/variar/klogg/assets/431260/d1aee513-7c5d-4401-84dc-9b47b30a30d9)

Line in the middle of document (after fix):
![4-b](https://github.com/variar/klogg/assets/431260/8324faa4-5ce6-44db-bdff-7911233e67a3)
