### PR TITLE
trigger the highlisters menu without closing

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/filteredview.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/highlightersdialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/highlighteredit.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/highlightersmenu.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/highlightersetedit.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/highlighterset.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/predefinedfilters.cpp

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/logmainview.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/mainwindow.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/mainwindowtext.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/menuactiontooltipbehavior.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/menu.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/optionsdialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/overview.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/overviewwidget.h
@@ -66,7 +66,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/logmainview.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/mainwindow.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/mainwindowtext.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/menuactiontooltipbehavior.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/menu.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/optionsdialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/overview.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/overviewwidget.cpp

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -69,6 +69,7 @@
 class QMenu;
 class QAction;
 class QShortcut;
+class HighlightersMenu;
 
 // Utility class representing a buffer for number entered on the keyboard
 // The buffer keep at most 7 digits, and reset itself after a timeout.
@@ -299,7 +300,6 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     void setSelectionStart();
     void setSelectionEnd();
     void setQuickFindResult( bool hasMatch, const Portion& selection );
-    void setHighlighterSet( QAction* action );
     void setColorLabel( QAction* action );
 
   private:
@@ -397,7 +397,7 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     QAction* setSelectionStartAction_;
     QAction* setSelectionEndAction_;
     QAction* saveDefaultSplitterSizesAction_;
-    QMenu* highlightersMenu_;
+    HighlightersMenu* highlightersMenu_;
     QMenu* colorLabelsMenu_;
 
     std::map<QString, QShortcut*> shortcuts_;

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -238,6 +238,7 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     void addColorLabel( size_t label );
     void addNextColorLabel();
     void clearColorLabels();
+    void highlightersChange();
 
   public Q_SLOTS:
     // Makes the widget select and display the passed line.

--- a/src/ui/include/highlighterset.h
+++ b/src/ui/include/highlighterset.h
@@ -44,9 +44,9 @@
 #include <QRegularExpression>
 #include <qcolor.h>
 
+#include "containers.h"
 #include "highlightedmatch.h"
 #include "persistable.h"
-#include "containers.h"
 
 struct HighlightColor {
     QColor foreColor;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -40,6 +40,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QMenu>
 #include <QSystemTrayIcon>
 #include <QTemporaryDir>
 

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -65,6 +65,7 @@ class QAction;
 class QActionGroup;
 class Session;
 class RecentFiles;
+class HighlightersMenu;
 
 // Main window of the application, creates menus, toolbar and
 // the CrawlerWidget
@@ -109,7 +110,6 @@ class MainWindow : public QMainWindow {
     void openFileFromRecent( QAction* action );
     void openFileFromFavorites( QAction* action );
     void switchToOpenedFile( QAction* action );
-    void setCurrentHighlighter( QAction* action );
     void closeTab( ActionInitiator initiator );
     void closeAll( ActionInitiator initiator );
     void selectAll();
@@ -237,7 +237,7 @@ class MainWindow : public QMainWindow {
     QMenu* viewMenu;
     QMenu* toolsMenu;
     QMenu* favoritesMenu;
-    QMenu* highlightersMenu;
+    HighlightersMenu* highlightersMenu;
     QMenu* openedFilesMenu;
     QMenu* helpMenu;
 

--- a/src/ui/include/menu.h
+++ b/src/ui/include/menu.h
@@ -17,45 +17,61 @@
  * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MANUACTIONTOOLTIPBEHAVIOR_H
-#define MANUACTIONTOOLTIPBEHAVIOR_H
+#ifndef KLOGG_MENU_H
+#define KLOGG_MENU_H
 
+#include <QMenu>
 #include <QObject>
 #include <QPoint>
 
 class QAction;
 class QMenu;
 class QTimerEvent;
-
+class QPoint;
 
 // Provides a behavior to show an action's tooltip after mouse is unmoved for
 // a specified number of 'ms'. E.g. used for tooltips with full-path for recent
 // files in the file menu. Not thread-safe.
-class MenuActionToolTipBehavior : public QObject
-{
+class MenuActionToolTipBehavior : public QObject {
     Q_OBJECT
 
- public:
-    MenuActionToolTipBehavior(QAction *menuAction, QMenu *menuParent,
-                              QObject *parent);
+  public:
+    MenuActionToolTipBehavior( QAction* menuAction, QMenu* menuParent, QObject* parent );
 
     // Time in ms that mouse needs to stay unmoved for tooltip to be shown
     int toolTipDelay(); /* ms */
-    void setToolTipDelay(int ms);
+    void setToolTipDelay( int ms );
 
- private:
-    void timerEvent(QTimerEvent *event) override;
-    void showToolTip(const QPoint &position);
+  private:
+    void timerEvent( QTimerEvent* event ) override;
+    void showToolTip( const QPoint& position );
 
- private Q_SLOTS:
+  private Q_SLOTS:
     void onActionHovered();
 
- private:
-    QAction *action;
-    QMenu *parentMenu;
+  private:
+    QAction* action;
+    QMenu* parentMenu;
     int toolTipDelayMs;
     int timerId;
     QPoint hoverPoint;
 };
 
-#endif
+class HoverMenu : public QMenu {
+  public:
+    explicit HoverMenu( const QString& title, QWidget* parent = nullptr );
+
+    void mouseMoveEvent( QMouseEvent* ) override;
+    void mouseReleaseEvent( QMouseEvent* ) override;
+
+  private:
+    inline bool mouseInMenu( const QPoint& pos )
+    {
+        return this->rect().contains( pos );
+    }
+
+  private:
+    bool mouseInMenu_;
+};
+
+#endif // KLOGG_MENU_H

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -657,7 +657,7 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
 
         highlightersMenu_->createHighlightersMenu();
         highlightersMenu_->populateHighlightersMenu();
-        highlightersMenu_->setApplyChange( [ this ]() { forceRefresh(); } );
+        highlightersMenu_->setApplyChange( [ this ]() { Q_EMIT highlightersChange(); } );
 
         auto colorLablesActionGroup = new QActionGroup( this );
         connect( colorLablesActionGroup, &QActionGroup::triggered, this,

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -655,12 +655,9 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
             replaceSearchAction_->setEnabled( false );
         }
 
-        auto highlightersActionGroup = new QActionGroup( this );
-        highlightersActionGroup->setExclusive( false );
-        connect( highlightersActionGroup, &QActionGroup::triggered, this,
-                 &AbstractLogView::setHighlighterSet );
-        highlightersMenu_->clear();
-        populateHighlightersMenu( highlightersMenu_, highlightersActionGroup );
+        highlightersMenu_->createHighlightersMenu();
+        highlightersMenu_->populateHighlightersMenu();
+        highlightersMenu_->setApplyChange( [ this ]() { forceRefresh(); } );
 
         auto colorLablesActionGroup = new QActionGroup( this );
         connect( colorLablesActionGroup, &QActionGroup::triggered, this,
@@ -717,7 +714,8 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
         }
         // Display the popup (blocking)
         popupMenu_->exec( QCursor::pos( activeScreen( this ) ) );
-        highlightersActionGroup->deleteLater();
+
+        highlightersMenu_->clearHighlightersMenu();
         colorLablesActionGroup->deleteLater();
     }
 
@@ -2173,7 +2171,8 @@ void AbstractLogView::createMenu()
              [ this ]( auto ) { Q_EMIT replaceScratchpadWithSelection(); } );
 
     popupMenu_ = new QMenu( this );
-    highlightersMenu_ = popupMenu_->addMenu( tr( "Highlighters" ) );
+    highlightersMenu_ = new HighlightersMenu( tr( "Highlighters" ) );
+    popupMenu_->addMenu( highlightersMenu_ );
     colorLabelsMenu_ = popupMenu_->addMenu( tr( "Color labels" ) );
 
     popupMenu_->addSeparator();
@@ -2706,12 +2705,6 @@ void AbstractLogView::disableFollow()
 {
     Q_EMIT followModeChanged( false );
     followElasticHook_.hook( false );
-}
-
-void AbstractLogView::setHighlighterSet( QAction* action )
-{
-    saveCurrentHighlighterFromAction( action );
-    forceRefresh();
 }
 
 void AbstractLogView::setColorLabel( QAction* action )

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -1207,6 +1207,9 @@ void CrawlerWidget::setup()
 
     connect( logMainView_, &LogMainView::markLines, this, &CrawlerWidget::markLinesFromMain );
 
+    connect( logMainView_, &LogMainView::highlightersChange, this,
+             &CrawlerWidget::applyConfiguration );
+
     connect( logMainView_, QOverload<const QString&>::of( &LogMainView::addToSearch ), this,
              &CrawlerWidget::addToSearch );
 
@@ -1362,6 +1365,8 @@ void CrawlerWidget::connectAllFilteredViewSlots( FilteredView* view )
     connect( view, &FilteredView::newSelection, this, &CrawlerWidget::jumpToMatchingLine );
 
     connect( view, &FilteredView::markLines, this, &CrawlerWidget::markLinesFromFiltered );
+
+    connect( view, &FilteredView::highlightersChange, this, &CrawlerWidget::applyConfiguration );
 
     connect( view, QOverload<const QString&>::of( &FilteredView::addToSearch ), this,
              &CrawlerWidget::addToSearch );

--- a/src/ui/src/highlightersmenu.cpp
+++ b/src/ui/src/highlightersmenu.cpp
@@ -1,0 +1,106 @@
+#include "highlightersmenu.h"
+
+#include "mainwindow.h"
+#include <qaction.h>
+
+HighlightersMenu::HighlightersMenu( const QString& title, QWidget* parent )
+    : HoverMenu( title, parent )
+    , highLighters_{ nullptr }
+    , applyChange_{}
+{
+    connect( this, &QMenu::aboutToShow, this, &HighlightersMenu::updateActionsStatus );
+}
+
+void HighlightersMenu::applySelectionHighlighters( QAction* action ) const
+{
+    saveCurrentHighlighterFromAction( action );
+
+    if ( !applyChange_ ) {
+        return;
+    }
+    applyChange_();
+
+    updateActionsStatus();
+}
+
+void HighlightersMenu::clearHighlightersMenu()
+{
+    clear();
+
+    if ( highLighters_ ) {
+        highLighters_->deleteLater();
+    }
+}
+
+void HighlightersMenu::createHighlightersMenu()
+{
+    highLighters_ = new QActionGroup( this );
+    highLighters_->setExclusive( false );
+    connect( highLighters_, &QActionGroup::triggered, this,
+             &HighlightersMenu::applySelectionHighlighters );
+}
+
+void HighlightersMenu::populateHighlightersMenu()
+{
+    const auto& highlightersCollection = HighlighterSetCollection::get();
+    const auto& highlighterSets = highlightersCollection.highlighterSets();
+    const auto& activeSetIds = highlightersCollection.activeSetIds();
+
+    auto noneAction = addAction( tr( "None" ) );
+    noneAction->setActionGroup( highLighters_ );
+    noneAction->setEnabled( !activeSetIds.isEmpty() );
+
+    addSeparator();
+
+    for ( const auto& highlighter : qAsConst( highlighterSets ) ) {
+        auto setAction = addAction( highlighter.name() );
+        setAction->setActionGroup( highLighters_ );
+        setAction->setCheckable( true );
+        setAction->setChecked( activeSetIds.contains( highlighter.id() ) );
+        setAction->setData( highlighter.id() );
+    }
+}
+
+void HighlightersMenu::saveCurrentHighlighterFromAction( const QAction* action ) const
+{
+    auto setId = action->data().toString();
+    auto& highlighterSets = HighlighterSetCollection::get();
+
+    if ( setId.isEmpty() ) {
+        highlighterSets.deactivateAll();
+    }
+    else if ( action->isChecked() ) {
+        highlighterSets.activateSet( setId );
+    }
+    else {
+        highlighterSets.deactivateSet( setId );
+    }
+
+    highlighterSets.save();
+}
+
+void HighlightersMenu::updateActionsStatus() const
+{
+    const auto activeSets = HighlighterSetCollection::get().activeSetIds();
+
+    const auto selectNone = activeSets.isEmpty();
+
+    for ( auto* action : highLighters_->actions() ) {
+        const auto actionSet = action->data().toString();
+        // update "None" action state
+        if ( actionSet.isEmpty() ) {
+            action->setEnabled( !selectNone );
+        }
+        // update highlighter action state
+        action->setChecked( activeSets.contains( actionSet )
+                            || ( actionSet.isEmpty() && selectNone ) );
+    }
+}
+
+void HighlightersMenu::addAction( QAction* action, bool seq )
+{
+    addAction( action );
+    if ( seq ) {
+        addSeparator();
+    }
+}

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -94,6 +94,7 @@
 #include "klogg_version.h"
 #include "logger.h"
 #include "mainwindowtext.h"
+#include "menu.h"
 #include "openfilehelper.h"
 #include "optionsdialog.h"
 #include "predefinedfiltersdialog.h"
@@ -790,7 +791,8 @@ void MainWindow::createMenus()
 
     toolsMenu = menuBar()->addMenu( tr( menu::toolsTitle ) );
 
-    highlightersMenu = menuBar()->addMenu( tr( menu::highlightersTitle ) );
+    highlightersMenu = new HoverMenu( tr( menu::highlightersTitle ), menuBar() );
+    menuBar()->addMenu( highlightersMenu );
     connect( highlightersMenu, &QMenu::aboutToShow,
              [ this ]() { setCurrentHighlighterAction( highlightersActionGroup ); } );
 

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -94,7 +94,6 @@
 #include "klogg_version.h"
 #include "logger.h"
 #include "mainwindowtext.h"
-#include "menu.h"
 #include "openfilehelper.h"
 #include "optionsdialog.h"
 #include "predefinedfiltersdialog.h"
@@ -791,10 +790,14 @@ void MainWindow::createMenus()
 
     toolsMenu = menuBar()->addMenu( tr( menu::toolsTitle ) );
 
-    highlightersMenu = new HoverMenu( tr( menu::highlightersTitle ), menuBar() );
+    highlightersMenu = new HighlightersMenu( tr( menu::highlightersTitle ), menuBar() );
     menuBar()->addMenu( highlightersMenu );
-    connect( highlightersMenu, &QMenu::aboutToShow,
-             [ this ]() { setCurrentHighlighterAction( highlightersActionGroup ); } );
+    highlightersMenu->setApplyChange( [ this ]() {
+        auto crawler = currentCrawlerWidget();
+        if ( crawler != nullptr ) {
+            crawler->applyConfiguration();
+        }
+    } );
 
     toolsMenu->addAction( predefinedFiltersDialogAction );
 
@@ -1964,29 +1967,10 @@ void MainWindow::updateOpenedFilesMenu()
 
 void MainWindow::updateHighlightersMenu()
 {
-    highlightersMenu->clear();
-    if ( highlightersActionGroup ) {
-        highlightersActionGroup->deleteLater();
-    }
-
-    highlightersActionGroup = new QActionGroup( this );
-    highlightersActionGroup->setExclusive( false );
-    connect( highlightersActionGroup, &QActionGroup::triggered, this,
-             &MainWindow::setCurrentHighlighter );
-
-    highlightersMenu->addAction( editHighlightersAction );
-    highlightersMenu->addSeparator();
-
-    populateHighlightersMenu( highlightersMenu, highlightersActionGroup );
-}
-
-void MainWindow::setCurrentHighlighter( QAction* action )
-{
-    saveCurrentHighlighterFromAction( action );
-
-    if ( auto current = currentCrawlerWidget() ) {
-        current->applyConfiguration();
-    }
+    highlightersMenu->clearHighlightersMenu();
+    highlightersMenu->createHighlightersMenu();
+    highlightersMenu->addAction( editHighlightersAction, true );
+    highlightersMenu->populateHighlightersMenu();
 }
 
 void MainWindow::updateFavoritesMenu()

--- a/src/ui/src/menu.cpp
+++ b/src/ui/src/menu.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <QAction>
+#include <QActionGroup>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QRect>

--- a/src/ui/src/menu.cpp
+++ b/src/ui/src/menu.cpp
@@ -19,11 +19,13 @@
 
 #include <QAction>
 #include <QMenu>
+#include <QMouseEvent>
+#include <QRect>
 #include <QTimerEvent>
 #include <QToolTip>
 
 #include "active_screen.h"
-#include "menuactiontooltipbehavior.h"
+#include "menu.h"
 
 // It would be nice to only need action, and have action be the parent,
 // however implementation needs the parent menu (see showToolTip), and
@@ -107,4 +109,36 @@ void MenuActionToolTipBehavior::showToolTip( const QPoint& position )
     QPoint relativePos = parentMenu->mapFromGlobal( position );
     QRect activeRegion( relativePos.x(), relativePos.y(), 1, 1 );
     QToolTip::showText( position, toolTip, parentMenu, activeRegion );
+}
+
+HoverMenu::HoverMenu( const QString& title, QWidget* parent )
+    : QMenu( title, parent )
+    , mouseInMenu_{ false }
+{
+}
+
+void HoverMenu::mouseMoveEvent( QMouseEvent* ev )
+{
+    auto nowMousePosition = mouseInMenu( ev->pos() );
+
+    // hide the menu list if the mouse leaves the menu.
+    if ( mouseInMenu_ && !nowMousePosition ) {
+        this->hide();
+    }
+    mouseInMenu_ = nowMousePosition;
+
+    QMenu::mouseMoveEvent( ev );
+}
+
+void HoverMenu::mouseReleaseEvent( QMouseEvent* ev )
+{
+    auto* action = this->actionAt( ev->pos() );
+
+    // responds to left-click event only
+    if ( action != nullptr && ev->button() == Qt::LeftButton ) {
+        action->activate( QAction::ActionEvent::Trigger );
+    }
+    else {
+        QMenu::mouseReleaseEvent( ev );
+    }
 }


### PR DESCRIPTION
This pull request is to add a feature(#551). But some bugs were found during development, so I fixed it by the way.
Modify as follows：
- When clicking the action in the highlighters menu, the menu list is not hidden
- Fix the display error of None Action in the highlighters menu
- Fix that the highlighters in the right-click menu only take effect in the current logview

## before
![img_v2_6cbd759b-5ab2-47c7-b827-cbc21421501l](https://github.com/variar/klogg/assets/31587297/106eed2c-1d55-4c44-ab91-ba4345dde902)
## fixed
![img_v2_33888b57-66c3-4fce-81e0-eb2df8672d1l](https://github.com/variar/klogg/assets/31587297/3c0c43f5-70a6-4d6e-b8a3-62704b2e35f4)
