### PR TITLE
feat: show tooltips for recent files

### DIFF
--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -75,6 +75,7 @@
 #include <QTemporaryFile>
 #include <QTextBrowser>
 #include <QToolBar>
+#include <QToolTip>
 #include <QUrl>
 #include <QUrlQuery>
 #include <QWindow>
@@ -493,6 +494,9 @@ void MainWindow::createActions()
     connect( recentFilesGroup, &QActionGroup::triggered, this, &MainWindow::openFileFromRecent );
     for ( auto i = 0u; i < recentFileActions.size(); ++i ) {
         recentFileActions[ i ] = new QAction( this );
+        connect( recentFileActions[ i ], &QAction::hovered, [ this, a = recentFileActions[ i ] ]() {
+            QToolTip::showText( QCursor::pos(), a->toolTip(), this );
+        } );
         recentFileActions[ i ]->setVisible( false );
         recentFileActions[ i ]->setActionGroup( recentFilesGroup );
     }


### PR DESCRIPTION
Recently files with the same filename could not be distinguished correctly, so a tooltips was added.
![Peek 2023-08-07 20-04](https://github.com/variar/klogg/assets/31587297/127b4cc4-71f3-4d69-ad34-d443070cdddb)
