### PR TITLE
fix: untabify function work error(#663)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,14 +5,12 @@ BreakBeforeBinaryOperators: true
 ColumnLimit: 100
 Standard: c++17
 IndentWidth: 4
-BreakBeforeBraces: Linux
 
 # Glogg-specific options
 PointerAlignment: Left
 SpacesInParentheses: true
 SpacesInSquareBrackets: true
 # DerivePointerAlignment: true
-AccessModifierOffset: -2
 
 BreakBeforeBraces: Custom
 BraceWrapping:

--- a/src/logdata/include/linetypes.h
+++ b/src/logdata/include/linetypes.h
@@ -268,7 +268,7 @@ QDebug operator<<( QDebug dbg, type_safe::strong_typedef<Tag, T> const& object )
 
 // Represents a position in a file (line, column)
 class FilePosition {
-  public:
+public:
     FilePosition()
         : column_{ -1 }
     {
@@ -298,7 +298,7 @@ class FilePosition {
         return !this->operator==( other );
     }
 
-  private:
+private:
     LineNumber line_;
     LineColumn column_;
 };
@@ -308,17 +308,14 @@ constexpr int TabStop = 8;
 
 inline QString untabify( QString&& line, LineColumn initialPosition = 0_lcol )
 {
-    LineLength::UnderlyingType totalSpaces = 0;
     line.replace( QChar::Null, QChar::Space );
 
     LineLength::UnderlyingType position = 0;
     position = type_safe::narrow_cast<LineLength::UnderlyingType>(
         line.indexOf( QChar::Tabulation, position ) );
     while ( position >= 0 ) {
-        const auto spaces
-            = TabStop - ( ( initialPosition.get() + position + totalSpaces ) % TabStop );
+        const auto spaces = TabStop - ( ( initialPosition.get() + position ) % TabStop );
         line.replace( position, 1, QString( spaces, QChar::Space ) );
-        totalSpaces += spaces - 1;
         position = type_safe::narrow_cast<LineLength::UnderlyingType>(
             line.indexOf( QChar::Tabulation, position ) );
     }


### PR DESCRIPTION
This PR is to resolve the tab alignment issue in #663, this commit also removes the conflicting configuration from the .clang-format file.
**Before**
![image](https://github.com/variar/klogg/assets/31587297/4f2873b9-c589-435e-99a0-b96463c169aa)
**After**
![image](https://github.com/variar/klogg/assets/31587297/9cf3ddc3-e577-430c-9e15-bf6f9e3f8f85)
