### PR TITLE
Optimize Dockerfiles for all Docker images

### DIFF
--- a/docker/oracle7/Dockerfile
+++ b/docker/oracle7/Dockerfile
@@ -2,15 +2,16 @@ FROM oraclelinux:7
 
 COPY epel.repo /etc/yum.repos.d
 
-RUN yum update -y
-
-RUN yum install -y ragel make wget rpm-build git \
+RUN yum update -y && \
+    yum install -y ragel make wget rpm-build git \
     qt5-qtbase-devel openssl-devel boost-devel zlib-devel \
-    devtoolset-7-gcc devtoolset-7-gcc-c++ ninja-build
+    devtoolset-7-gcc devtoolset-7-gcc-c++ ninja-build && \
+    yum clean all
 
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
     chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license
+    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm cmake-3.20.2-linux-x86_64.sh
 
 ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:/opt/bin:$PATH
 

--- a/docker/oracle8/Dockerfile
+++ b/docker/oracle8/Dockerfile
@@ -2,19 +2,20 @@ FROM oraclelinux:8
 
 COPY epel.repo /etc/yum.repos.d
 
-RUN yum update -y
-
-RUN yum install -y ragel make wget python38 rpm-build git \
+RUN yum update -y && \
+    yum install -y ragel make wget python38 rpm-build git \
     qt5-qtbase-devel qt5-linguist qt5-qttranslations \
     openssl-devel boost-devel zlib-devel libcurl-devel \
-    gcc gcc-c++ elfutils-devel
+    gcc gcc-c++ elfutils-devel && \
+    yum clean all
 
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
     chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license
+    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm cmake-3.20.2-linux-x86_64.sh
 
 RUN wget https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip && \
-    unzip ninja-linux.zip && chmod 755 ninja && mv ninja /opt/bin
+    unzip ninja-linux.zip && chmod 755 ninja && mv ninja /opt/bin && rm ninja-linux.zip
 
 ENV PATH=/opt/bin:$PATH
 

--- a/docker/ubuntu18.04/Dockerfile
+++ b/docker/ubuntu18.04/Dockerfile
@@ -2,17 +2,17 @@ FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -y
-
-RUN apt install build-essential \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends build-essential \
                     qtbase5-dev qt5-qmake qtbase5-dev-tools qttools5-dev qttranslations5-l10n \
                     libboost-dev libicu-dev libssl-dev libcurl4-openssl-dev \
                     ragel ninja-build zlib1g-dev git \
-                    wget fuse -y && \
-    apt clean && rm -rf /var/lib/apt/lists/*
+                    wget ca-certificates fuse -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
     chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license
+    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm cmake-3.20.2-linux-x86_64.sh
 
 ENV PATH=/opt/bin:$PATH

--- a/docker/ubuntu18.04_qt5.15/Dockerfile
+++ b/docker/ubuntu18.04_qt5.15/Dockerfile
@@ -3,11 +3,10 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
-    apt-get install software-properties-common -y && \
+    apt-get install --no-install-recommends software-properties-common -y && \
     add-apt-repository ppa:beineri/opt-qt-5.15.2-bionic -y && \
-    apt-get update -y
-
-RUN apt-get install build-essential \
+    apt-get update -y && \
+    apt-get install --no-install-recommends build-essential \
                     qt515base qt515svg qt515tools qt515imageformats qt515translations \
                     mesa-common-dev libglu1-mesa-dev \
                     libboost-dev libicu-dev libssl-dev libcurl4-openssl-dev \
@@ -17,6 +16,7 @@ RUN apt-get install build-essential \
 
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
     chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license
+    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm cmake-3.20.2-linux-x86_64.sh
 
 ENV PATH=/opt/bin:/opt/qt515/bin:$PATH

--- a/docker/ubuntu20.04/Dockerfile
+++ b/docker/ubuntu20.04/Dockerfile
@@ -2,17 +2,17 @@ FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -y
-
-RUN apt install build-essential \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends build-essential \
                     qtbase5-dev qt5-qmake qtbase5-dev-tools qttools5-dev qttranslations5-l10n\
                     libboost-dev libssl-dev libicu-dev libcurl4-openssl-dev \
                     ragel ninja-build zlib1g-dev git \
-                    wget fuse -y && \
-    apt clean && rm -rf /var/lib/apt/lists/*
+                    wget ca-certificates fuse -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
     chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license
+    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm cmake-3.20.2-linux-x86_64.sh
 
 ENV PATH=/opt/bin:$PATH

--- a/docker/ubuntu22.04/Dockerfile
+++ b/docker/ubuntu22.04/Dockerfile
@@ -2,17 +2,17 @@ FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -y
-
-RUN apt install build-essential \
+RUN apt update -y && \
+    apt install --no-install-recommends build-essential \
                     qtbase5-dev qt5-qmake qtbase5-dev-tools qttools5-dev qttranslations5-l10n \
                     libboost-dev libssl-dev libcurl4-openssl-dev \
                     ragel ninja-build zlib1g-dev git \
-                    wget fuse file -y && \
+                    wget ca-certificates fuse file -y && \
     apt clean && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
     chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license
+    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm cmake-3.20.2-linux-x86_64.sh
 
 ENV PATH=/opt/bin:$PATH


### PR DESCRIPTION
This commit optimizes the Dockerfiles for both Oracle and Ubuntu Docker images to enhance efficiency, reduce image size, and ensure adherence to best practices.

1. Consolidate `RUN` commands: This reduces Docker image layers and allows effective cleanup within the same layer.

2. Standardize on apt-get over apt: apt is designed for interactive use, while apt-get provides a stable CLI interface for scripting. This change ensures script stability and consistency in Dockerfiles.

3. Adjust package installation: Use `--no-install-recommends` with `apt-get install` to avoid unnecessary packages and explicitly install `ca-certificates` in Ubuntu Docker images for `wget` to function correctly with HTTPS.

4. Remove temporary installation files: Further reduces Docker image size by cleaning up unused files post-installation.

These changes overall streamline the Dockerfiles, leading to more efficient and smaller Docker images.

Here's the result of the optimization, which is significant:
```
REPOSITORY             TAG        IMAGE ID       CREATED        SIZE
ubuntu22.04            after      ba8a163bd647   1 hours ago    1.22GB
ubuntu22.04            before     444d0d9ade14   1 hours ago    1.51GB
ubuntu20.04            after      9cfbaf385492   1 hours ago    1.15GB
ubuntu20.04            before     1f77992b16dc   1 hours ago    1.89GB
ubuntu18.04_qt5.15     after      6a3c4b985091   1 hours ago    1.13GB
ubuntu18.04_qt5.15     before     904e72f3c332   1 hours ago    1.24GB
ubuntu18.04            after      f2be07fdd124   1 hours ago    953MB
ubuntu18.04            before     72288345a99f   1 hours ago    1.17GB
oracle8                after      91fa597e5366   1 hours ago    1.1GB
oracle8                before     e4cb6d5953d2   1 hours ago    1.63GB
oracle7                after      4b03e24f6a86   1 hours ago    913MB
oracle7                before     cf32ac6dfd47   1 hours ago    1.91GB
```