### PR TITLE
docs: Fix build instructions for Linux

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -9,6 +9,7 @@ will be enabled if available on build machine.
 ## Getting the Source
 
 This project is [hosted on GitHub](https://github.com/variar/klogg). You can clone this project directly using this command:
+
 ```
 git clone https://github.com/variar/klogg
 ```
@@ -16,29 +17,32 @@ git clone https://github.com/variar/klogg
 ## Dependencies
 
 To build Klogg:
- * cmake 3.12 or later to generate build files
- * C++ compiler with decent C++17 support (at least gcc 7.5, clang 7, msvc 19.14)
- * Qt libraries 5.9 or later (CI builds use Qt 5.9.5/5.12.5/5.15.2):
-    - QtCore
-    - QtGui
-    - QtWidgets
-    - QtConcurrent
-    - QtNetwork
-    - QtXml
-    - QtTools
+
+- cmake 3.12 or later to generate build files
+- C++ compiler with decent C++17 support (at least gcc 7.5, clang 7, msvc 19.14)
+- Qt libraries 5.9 or later (CI builds use Qt 5.9.5/5.12.5/5.15.2):
+  - QtCore
+  - QtGui
+  - QtWidgets
+  - QtConcurrent
+  - QtNetwork
+  - QtXml
+  - QtTools
 
 To build Hyperscan regular expressions backend (default):
- * CPU with support for [SSSE3](https://en.wikipedia.org/wiki/SSSE3) instructions (for Hyperscan backend)
- * Boost (1.58 or later, header-only part)
- * Ragel (6.8 or later; precompiled binary is provided for Windows; has to be installed from package managers on Linux or Homebrew on Mac)
+
+- CPU with support for [SSSE3](https://en.wikipedia.org/wiki/SSSE3) instructions (for Hyperscan backend)
+- Boost (1.58 or later, header-only part)
+- Ragel (6.8 or later; precompiled binary is provided for Windows; has to be installed from package managers on Linux or Homebrew on Mac)
 
 To build installer for Windows:
- * nsis to build installer for Windows
- * Precompiled OpenSSl library to enable https support on Windows
+
+- nsis to build installer for Windows
+- Precompiled OpenSSl library to enable https support on Windows
 
 Building tests:
- * QtTest
 
+- QtTest
 
 All other dependencies are provided by [CPM](https://github.com/cpm-cmake/CPM.cmake) during cmake configuration stage (see 3rdparty directory).
 
@@ -63,6 +67,7 @@ Memory allocator override can be turned off by passing `-DKLOGG_OVERRIDE_MALLOC`
 Here is how to build klogg on Ubuntu 18.04.
 
 Install dependencies:
+
 ```
 sudo apt-get install build-essential cmake qtbase5-dev libboost-all-dev ragel
 ```
@@ -75,6 +80,12 @@ mkdir build_root
 cd build_root
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 cmake --build .
+```
+
+**_If cmake gives error about missing "Qt5LinguistTools" configuration files, try running:_**
+
+```bash
+sudo apt-get install qttools5-dev
 ```
 
 Binaries are placed into `build_root/output`.
@@ -97,25 +108,31 @@ Extract to some folder. Directory structure should be something like `C:\Boost\b
 Then add `BOOST_ROOT` environment variable pointing to main directory of Boost sources so CMake is able to fine it.
 
 Prepare build environment for CMake. Open command prompt window and depending on version of Visual Studio run either
+
 ```
 call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\Tools\vsdevcmd" -arch=x64
 ```
+
 or
+
 ```
 call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd" -arch=x64
 ```
 
 Next setup Qt paths:
+
 ```
 <path_to_qt_installation>\bin\qtenv2.bat
 ```
 
 Then add CMake to PATH:
+
 ```
 set PATH=<path_to_cmake_bin>:$PATH
 ```
 
 Configure klogg solution (use CMake generator matching Visual Studio version):
+
 ```
 cd <path_to_project_root>
 md build_root
@@ -135,6 +152,7 @@ Put libcrypto-1_1 and libssl-1_1 for desired architecture near klogg binaries.
 Klogg requires macOS High Sierra (10.13) or higher.
 
 Install [Homebrew](https://brew.sh/) using terminal:
+
 ```
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
@@ -142,6 +160,7 @@ Install [Homebrew](https://brew.sh/) using terminal:
 Homebrew installer should also install xcode command line tools.
 
 Download and install build dependencies:
+
 ```
 brew install cmake ninja qt boost ragel
 ```
@@ -149,6 +168,7 @@ brew install cmake ninja qt boost ragel
 Usually path to qt installation looks like `/usr/local/Cellar/qt/5.14.0/lib/cmake/Qt5`
 
 Configure and build klogg:
+
 ```
 cd <path_to_klogg_repository_clone>
 mkdir build_root
@@ -164,11 +184,12 @@ To override default cmake value pass an option `-DKLOGG_OSX_DEPLOYMENT_TARGET=<t
 `<target>` is one of `10.14`, `10.15`, `11`, `12`. Klogg's traget must be greater or equal to target used by Qt libraries.
 
 ## Running tests
+
 Tests are built by default. To turn them off pass `-DBUILD_TESTS:BOOL=OFF` to cmake.
 Tests use catch2 (bundled with klogg sources) and require Qt5Test module. Tests can be run using ctest tool provider by CMake:
+
 ```
 cd <path_to_klogg_repository_clone>
 cd build_root
 ctest --build-config RelWithDebInfo --verbose
 ```
-


### PR DESCRIPTION
Cmake was showing an error related to missing config files for ```Qt5LinguistTools``` while building on Ubuntu.