### PR TITLE
fix: bottom view line in overview is now calculated correctly.

### DIFF
--- a/src/ui/src/overview.cpp
+++ b/src/ui/src/overview.cpp
@@ -82,8 +82,7 @@ std::pair<int, int> Overview::getViewLines() const
     if ( linesInFile_.get() > 0 ) {
         top = static_cast<int>( ( topLine_.get() ) * height_ / ( linesInFile_.get() ) );
 
-        bottom = static_cast<int>( ( static_cast<unsigned>( top ) + nbLines_.get() ) * height_
-                                   / ( linesInFile_.get() ) );
+        bottom = top + static_cast<int>( nbLines_.get() * height_ / ( linesInFile_.get() ) );
     }
 
     return std::make_pair( top, bottom );


### PR DESCRIPTION
I noticed that when viewing files, the "view lines" shown on the overview did not line up with the actual lines that were being viewed. Instead, one of the lines would always remain near the top of the file.

This is because [this change](https://github.com/variar/klogg/commit/151a65c08ba772468bba651f05f381e9e34eeb9a) added some extra brackets to `Overview::getViewLines()` that changed the order of operations in the calculation of `bottom`. I've fixed up the order of operations for this calculation.

Original working code:
`bottom = (int)((qint64)top + nbLines_.get() * height_ / linesInFile_.get());`

Code with incorrect order of operations:
`bottom = static_cast<int>( ( static_cast<unsigned>( top ) + nbLines_.get() ) * height_
                                   / ( linesInFile_.get() ) );`

Fixed code:
`bottom = top + static_cast<int>( nbLines_.get() * height_ / ( linesInFile_.get() ) );`