### PR TITLE
added support for loongarch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,8 @@ else()
 
   if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
     ucm_add_flags(C CXX "-march=native -mtune=generic")
+  elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "loongarch64")
+    ucm_add_flags(C CXX "-march=native -mtune=generic")
   else()
     ucm_add_flags(C CXX "-mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt")
     if(KLOGG_GENERIC_CPU)

--- a/src/utils/src/cpu_info.cpp
+++ b/src/utils/src/cpu_info.cpp
@@ -89,7 +89,8 @@ CpuInstructions supportedCpuInstructions()
 CpuInstructions supportedCpuInstructions()
 {
     CpuInstructions cpuInstructions = CpuInstructions::NONE;
-
+#if defined(__loongarch__)
+#else
     if ( __builtin_cpu_supports( "avx512f" ) ) {
         cpuInstructions |= CpuInstructions::SSE2;
         cpuInstructions |= CpuInstructions::SSE3;
@@ -134,6 +135,7 @@ CpuInstructions supportedCpuInstructions()
     if ( __builtin_cpu_supports( "popcnt" ) ) {
         cpuInstructions |= CpuInstructions::POPCNT;
     }
+#endif
     return cpuInstructions;
 }
 #else


### PR DESCRIPTION
tested pass on loongarch, build with:
```
cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DKLOGG_USE_HYPERSCAN=OFF -DKLOGG_USE_VECTORSCAN=OFF -DKLOGG_BUILD_TESTS=OFF ..
cmake --build .
```
KLOGG_BUILD_TESTS must be OFF as backward-cpp leak support for loongarch. (I created a [PR](https://github.com/bombela/backward-cpp/pull/348) for it)

Attachment is test log:
[test.log](https://github.com/user-attachments/files/19088824/test.log)
